### PR TITLE
feat: stateful mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Available expression tokens:
 | Token | Description |
 | ------- | ------------- |
 | `verb` | HTTP method of the call |
+| `state` | The state value set through RouteDefinition.setState |
 | `query("key")` | Query string parameter |
 | `header("key")` | Request header (case-insensitive) |
 | `route("key")` | Captured route parameter |

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 </div>
 
 > [!WARNING]
-> This project is still in a pre-release state. Use at your own risk.
+> This project is still in a super-pre-release state. Use at your own risk.
 
 Bamboozle is a container-native HTTP mock server for integration testing. It intercepts real HTTP traffic, allowing you to test your full client stack — serialisation, authentication headers, retry logic, circuit breakers — without any live dependency.
 
 Unlike in-process mocking libraries, Bamboozle runs as a self-contained Docker container that is fully programmable at runtime from your test code, or configurable from startup files.
 
-This readme discusses the app; we have a collection of SDKs to help you leverage the app in your language of choice.
+This readme discusses the app; we are working on a collection of SDKs to help you leverage the app in your language of choice.
 
 ## How it works
 
@@ -119,6 +119,7 @@ Response bodies, headers, and status codes support [Liquid](https://shopify.gith
 | `{{ headers }}` | Request header |
 | `{{ body }}` | Parsed JSON body |
 | `{{ bodyRaw }}` | Raw request body as a string |
+| `{{ previousContext }}` | The context from the previous request (if it exists) |
 
 Example — echo the captured ID back in a JSON response:
 
@@ -248,7 +249,6 @@ Scalar API reference is available at `http://localhost:9090/` when the container
 Bamboozle is built against a detailed design specification. The following capabilities are planned but not yet implemented:
 
 - **Request matching on content** — match routes based on headers, query parameters, and request body (JSON path conditions and schema validation), in addition to verb and path
-- **Response sequences** — return different responses on successive calls to the same route, enabling stateful mock scenarios (e.g. first call returns `202`, second returns `409`)
 - **Delay simulation** — configurable fixed, random, and gaussian latency to test client timeout handling and retry behaviour
 - **Fault simulation** — connection reset and empty response injection to test client resilience against network failures
 - **Session isolation** — per-test namespace via a session header, enabling safe parallel test execution against a shared Bamboozle instance

--- a/bamboozle/Cargo.lock
+++ b/bamboozle/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "bamboozle"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/bamboozle/Cargo.toml
+++ b/bamboozle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bamboozle"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
 [[bin]]

--- a/bamboozle/src/expression.rs
+++ b/bamboozle/src/expression.rs
@@ -156,8 +156,10 @@ mod tests {
             route_values: HashMap::new(),
             body: serde_json::Value::Null,
             body_raw: String::new(),
+            state: String::new(),
             route_model: RouteDefinition {
                 match_key: MatchKey::new("GET", "/test"),
+                set_state: None,
                 response: ResponseDefinition::default(),
             },
             previous_context: None,

--- a/bamboozle/src/expression.rs
+++ b/bamboozle/src/expression.rs
@@ -160,6 +160,7 @@ mod tests {
                 match_key: MatchKey::new("GET", "/test"),
                 response: ResponseDefinition::default(),
             },
+            previous_context: None,
         }
     }
 

--- a/bamboozle/src/expression.rs
+++ b/bamboozle/src/expression.rs
@@ -10,6 +10,7 @@ use crate::models::context::ContextModel;
 /// Available variables and functions:
 ///   verb                     – HTTP method of the recorded call ("GET", "POST", …)
 ///   pattern                  – route pattern matched by the call
+///   state                    – computed state string from the setState template
 ///   query("key")             – value of a query-string parameter (empty string if absent)
 ///   header("key")            – value of a request header (empty string if absent)
 ///   route("key")             – value of a route-template capture (empty string if absent)
@@ -35,6 +36,7 @@ pub fn eval_expression(expr: &str, ctx: &ContextModel) -> Result<bool, EvalexprE
         "pattern"  => Value::String(ctx.route_model.match_key.pattern.clone()),
         "body"     => Value::String(body_str),
         "body_raw" => Value::String(ctx.body_raw.clone()),
+        "state"    => Value::String(ctx.state.clone()),
     }?;
 
     context.set_function(
@@ -261,6 +263,14 @@ mod tests {
             .insert("env".to_string(), "prod".to_string());
         assert!(eval_expression(r#"verb == "GET" && query("env") == "prod""#, &ctx).unwrap());
         assert!(!eval_expression(r#"verb == "POST" && query("env") == "prod""#, &ctx).unwrap());
+    }
+
+    #[test]
+    fn state_variable() {
+        let mut ctx = make_ctx();
+        ctx.state = "active".to_string();
+        assert!(eval_expression(r#"state == "active""#, &ctx).unwrap());
+        assert!(!eval_expression(r#"state == "inactive""#, &ctx).unwrap());
     }
 
     #[test]

--- a/bamboozle/src/liquid_render.rs
+++ b/bamboozle/src/liquid_render.rs
@@ -58,6 +58,7 @@ fn build_globals(ctx: &ContextModel) -> liquid::Object {
     globals.insert("routeValues".into(), map_to_value(&ctx.route_values));
     globals.insert("body".into(), json_to_liquid(&ctx.body));
     globals.insert("bodyRaw".into(), Value::scalar(ctx.body_raw.clone()));
+    globals.insert("state".into(), Value::scalar(ctx.state.clone()));
     globals.insert("routeModel".into(), route_model_to_value(&ctx.route_model));
     let prev = ctx
         .previous_context
@@ -75,6 +76,7 @@ fn context_to_object(ctx: &ContextModel) -> liquid::Object {
     obj.insert("routeValues".into(), map_to_value(&ctx.route_values));
     obj.insert("body".into(), json_to_liquid(&ctx.body));
     obj.insert("bodyRaw".into(), Value::scalar(ctx.body_raw.clone()));
+    obj.insert("state".into(), Value::scalar(ctx.state.clone()));
     obj.insert("routeModel".into(), route_model_to_value(&ctx.route_model));
     obj
 }
@@ -130,8 +132,10 @@ mod tests {
             route_values: HashMap::new(),
             body: serde_json::Value::Null,
             body_raw: String::new(),
+            state: String::new(),
             route_model: RouteDefinition {
                 match_key: MatchKey::new("GET", "/test"),
+                set_state: None,
                 response: ResponseDefinition::default(),
             },
             previous_context: None,

--- a/bamboozle/src/liquid_render.rs
+++ b/bamboozle/src/liquid_render.rs
@@ -1,5 +1,6 @@
 use liquid::model::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 use crate::models::context::ContextModel;
 use serde_json::Value as JsonValue;
@@ -37,8 +38,10 @@ impl Renderer {
         ctx: &ContextModel,
         fallback: &str,
     ) -> String {
-        self.render(template_str, ctx)
-            .unwrap_or_else(|_| fallback.to_string())
+        self.render(template_str, ctx).unwrap_or_else(|e| {
+            warn!(template = template_str, error = %e, "Template rendering failed, using fallback");
+            fallback.to_string()
+        })
     }
 }
 
@@ -55,7 +58,30 @@ fn build_globals(ctx: &ContextModel) -> liquid::Object {
     globals.insert("routeValues".into(), map_to_value(&ctx.route_values));
     globals.insert("body".into(), json_to_liquid(&ctx.body));
     globals.insert("bodyRaw".into(), Value::scalar(ctx.body_raw.clone()));
+    globals.insert("routeModel".into(), route_model_to_value(&ctx.route_model));
+    let prev = ctx
+        .previous_context
+        .as_deref()
+        .map(|p| Value::Object(context_to_object(p)))
+        .unwrap_or(Value::Nil);
+    globals.insert("previousContext".into(), prev);
     globals
+}
+
+fn context_to_object(ctx: &ContextModel) -> liquid::Object {
+    let mut obj = liquid::Object::new();
+    obj.insert("queryParams".into(), map_to_value(&ctx.query_params));
+    obj.insert("headers".into(), map_to_value(&ctx.headers));
+    obj.insert("routeValues".into(), map_to_value(&ctx.route_values));
+    obj.insert("body".into(), json_to_liquid(&ctx.body));
+    obj.insert("bodyRaw".into(), Value::scalar(ctx.body_raw.clone()));
+    obj.insert("routeModel".into(), route_model_to_value(&ctx.route_model));
+    obj
+}
+
+fn route_model_to_value(route_model: &crate::models::route::RouteDefinition) -> Value {
+    let json = serde_json::to_value(route_model).unwrap_or(JsonValue::Null);
+    json_to_liquid(&json)
 }
 
 fn map_to_value(map: &HashMap<String, String>) -> Value {
@@ -108,6 +134,7 @@ mod tests {
                 match_key: MatchKey::new("GET", "/test"),
                 response: ResponseDefinition::default(),
             },
+            previous_context: None,
         }
     }
 
@@ -186,5 +213,46 @@ mod tests {
             r.render_or_fallback("{{ queryParams.x }}", &ctx, "fallback"),
             "1"
         );
+    }
+
+    #[test]
+    fn route_model_verb_interpolation() {
+        let r = Renderer::new();
+        let ctx = make_ctx();
+        assert_eq!(
+            r.render("{{ routeModel.match.verb }}", &ctx).unwrap(),
+            "GET"
+        );
+    }
+
+    #[test]
+    fn route_model_pattern_interpolation() {
+        let r = Renderer::new();
+        let ctx = make_ctx();
+        assert_eq!(
+            r.render("{{ routeModel.match.pattern }}", &ctx).unwrap(),
+            "test"
+        );
+    }
+
+    #[test]
+    fn previous_context_interpolation() {
+        let r = Renderer::new();
+        let mut prev = make_ctx();
+        prev.route_values.insert("id".to_string(), "42".to_string());
+        let mut ctx = make_ctx();
+        ctx.previous_context = Some(Box::new(prev));
+        assert_eq!(
+            r.render("prev={{ previousContext.routeValues.id }}", &ctx)
+                .unwrap(),
+            "prev=42"
+        );
+    }
+
+    #[test]
+    fn previous_context_nil_when_absent() {
+        let r = Renderer::new();
+        let ctx = make_ctx();
+        assert_eq!(r.render("{{ previousContext }}", &ctx).unwrap(), "");
     }
 }

--- a/bamboozle/src/mock_server.rs
+++ b/bamboozle/src/mock_server.rs
@@ -68,12 +68,16 @@ async fn catch_all(
                     match_key: MatchKey::new(verb, path),
                     response: ResponseDefinition::default(),
                 },
+                previous_context: None,
             };
             state.tracker.record_unmatched(ctx);
             StatusCode::NOT_FOUND.into_response()
         }
 
         Some((route_def, route_values)) => {
+            let previous_context = state
+                .tracker
+                .get_last_matched_for_route(&route_def.match_key);
             let ctx = ContextModel {
                 query_params,
                 headers: header_map,
@@ -81,6 +85,7 @@ async fn catch_all(
                 body,
                 body_raw: body_raw.clone(),
                 route_model: route_def.clone(),
+                previous_context,
             };
             state.tracker.record_matched(ctx.clone());
 
@@ -142,6 +147,18 @@ mod tests {
                 ..Default::default()
             },
         }
+    }
+
+    async fn make_request(state: AppState, uri: &str) {
+        router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
     }
 
     async fn body_string(body: axum::body::Body) -> String {
@@ -347,5 +364,58 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn previous_context_is_null_on_first_call() {
+        let state = AppState::new();
+        state
+            .store
+            .set_route(make_route("GET", "/thing", Some("ok"), "200"))
+            .unwrap();
+        let tracker = state.tracker.clone();
+        make_request(state, "/thing").await;
+        let calls = tracker.get_calls_for_route(&MatchKey::new("GET", "/thing"));
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].previous_context.is_none());
+    }
+
+    #[tokio::test]
+    async fn previous_context_is_set_on_second_call() {
+        let state = AppState::new();
+        state
+            .store
+            .set_route(make_route("GET", "/thing", Some("ok"), "200"))
+            .unwrap();
+        let tracker = state.tracker.clone();
+        make_request(state.clone(), "/thing").await;
+        make_request(state, "/thing").await;
+        let calls = tracker.get_calls_for_route(&MatchKey::new("GET", "/thing"));
+        assert_eq!(calls.len(), 2);
+        assert!(calls.iter().any(|c| c.previous_context.is_some()));
+    }
+
+    #[tokio::test]
+    async fn previous_context_does_not_nest() {
+        let state = AppState::new();
+        state
+            .store
+            .set_route(make_route("GET", "/thing", Some("ok"), "200"))
+            .unwrap();
+        let tracker = state.tracker.clone();
+        make_request(state.clone(), "/thing").await;
+        make_request(state.clone(), "/thing").await;
+        make_request(state, "/thing").await;
+        let calls = tracker.get_calls_for_route(&MatchKey::new("GET", "/thing"));
+        let call_with_prev = calls
+            .iter()
+            .find(|c| c.previous_context.is_some())
+            .unwrap();
+        assert!(call_with_prev
+            .previous_context
+            .as_ref()
+            .unwrap()
+            .previous_context
+            .is_none());
     }
 }

--- a/bamboozle/src/mock_server.rs
+++ b/bamboozle/src/mock_server.rs
@@ -66,8 +66,10 @@ async fn catch_all(
                 body_raw,
                 route_model: RouteDefinition {
                     match_key: MatchKey::new(verb, path),
+                    set_state: None,
                     response: ResponseDefinition::default(),
                 },
+                state: String::new(),
                 previous_context: None,
             };
             state.tracker.record_unmatched(ctx);
@@ -78,7 +80,7 @@ async fn catch_all(
             let previous_context = state
                 .tracker
                 .get_last_matched_for_route(&route_def.match_key);
-            let ctx = ContextModel {
+            let mut ctx = ContextModel {
                 query_params,
                 headers: header_map,
                 route_values,
@@ -86,7 +88,13 @@ async fn catch_all(
                 body_raw: body_raw.clone(),
                 route_model: route_def.clone(),
                 previous_context,
+                state: String::new(),
             };
+
+            if let Some(set_state) = &route_def.set_state {
+                ctx.state = state.renderer.render_or_fallback(set_state, &ctx, "");
+            }
+
             state.tracker.record_matched(ctx.clone());
 
             let status_str =
@@ -141,6 +149,7 @@ mod tests {
     ) -> RouteDefinition {
         RouteDefinition {
             match_key: MatchKey::new(verb, pattern),
+            set_state: None,
             response: ResponseDefinition {
                 status: status.to_string(),
                 content: content.map(|s| s.to_string()),
@@ -246,6 +255,7 @@ mod tests {
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("POST", "/echo"),
+                set_state: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     loopback: Some(true),
@@ -303,6 +313,7 @@ mod tests {
                     verb: "GET".to_string(),
                     pattern: "/thing/{thingName}/{thingVersion}".to_string(),
                 },
+                set_state: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some(r#"{"id":"{{ routeValues.thingName }}"}"#.to_string()),
@@ -417,5 +428,66 @@ mod tests {
             .unwrap()
             .previous_context
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn set_state_template_is_rendered_and_stored() {
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/stateful"),
+                set_state: Some("hello-state".to_string()),
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    content: Some("{{ state }}".to_string()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        let tracker = state.tracker.clone();
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/stateful")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(body_string(response.into_body()).await, "hello-state");
+        let calls = tracker.get_calls_for_route(&MatchKey::new("GET", "/stateful"));
+        assert_eq!(calls[0].state, "hello-state");
+    }
+
+    #[tokio::test]
+    async fn previous_context_state_accessible_on_second_call() {
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/counter"),
+                set_state: Some(
+                    "{% if previousContext == nil %}0{% else %}{{ previousContext.state }}{% endif %}"
+                        .to_string(),
+                ),
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    content: Some("{{ state }}".to_string()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        make_request(state.clone(), "/counter").await;
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/counter")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(body_string(response.into_body()).await, "0");
     }
 }

--- a/bamboozle/src/models/context.rs
+++ b/bamboozle/src/models/context.rs
@@ -6,6 +6,7 @@ use utoipa::ToSchema;
 use super::route::RouteDefinition;
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(no_recursion)]
 pub struct ContextModel {
     #[serde(rename = "queryParams")]
     pub query_params: HashMap<String, String>,
@@ -17,4 +18,7 @@ pub struct ContextModel {
     pub body: JsonValue,
     #[serde(rename = "bodyRaw")]
     pub body_raw: String,
+    #[serde(rename = "previousContext")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_context: Option<Box<ContextModel>>,
 }

--- a/bamboozle/src/models/context.rs
+++ b/bamboozle/src/models/context.rs
@@ -18,6 +18,8 @@ pub struct ContextModel {
     pub body: JsonValue,
     #[serde(rename = "bodyRaw")]
     pub body_raw: String,
+    #[serde(default)]
+    pub state: String,
     #[serde(rename = "previousContext")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub previous_context: Option<Box<ContextModel>>,

--- a/bamboozle/src/models/route.rs
+++ b/bamboozle/src/models/route.rs
@@ -10,6 +10,8 @@ pub struct RouteDefinition {
     pub match_key: MatchKey,
     #[serde(default)]
     pub response: ResponseDefinition,
+    #[serde(rename = "setState", default, skip_serializing_if = "Option::is_none")]
+    pub set_state: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]

--- a/bamboozle/src/routing/store.rs
+++ b/bamboozle/src/routing/store.rs
@@ -157,6 +157,7 @@ mod tests {
     fn make_route(verb: &str, pattern: &str) -> RouteDefinition {
         RouteDefinition {
             match_key: MatchKey::new(verb, pattern),
+            set_state: None,
             response: ResponseDefinition::default(),
         }
     }

--- a/bamboozle/src/tracking/tracker.rs
+++ b/bamboozle/src/tracking/tracker.rs
@@ -92,8 +92,10 @@ mod tests {
             route_values: HashMap::new(),
             body: serde_json::Value::Null,
             body_raw: String::new(),
+            state: String::new(),
             route_model: RouteDefinition {
                 match_key: MatchKey::new(verb, pattern),
+                set_state: None,
                 response: ResponseDefinition::default(),
             },
             previous_context: None,

--- a/bamboozle/src/tracking/tracker.rs
+++ b/bamboozle/src/tracking/tracker.rs
@@ -7,6 +7,7 @@ use crate::models::{context::ContextModel, match_key::MatchKey};
 pub struct CallTracker {
     matched: DashMap<Uuid, ContextModel>,
     unmatched: DashMap<Uuid, ContextModel>,
+    last_matched: DashMap<MatchKey, ContextModel>,
 }
 
 impl CallTracker {
@@ -14,12 +15,22 @@ impl CallTracker {
         Self {
             matched: DashMap::new(),
             unmatched: DashMap::new(),
+            last_matched: DashMap::new(),
         }
     }
 
     pub fn record_matched(&self, ctx: ContextModel) {
         debug!(route = %ctx.route_model.match_key, "Recorded matched call");
+        self.last_matched.insert(ctx.route_model.match_key.clone(), ctx.clone());
         self.matched.insert(Uuid::new_v4(), ctx);
+    }
+
+    pub fn get_last_matched_for_route(&self, key: &MatchKey) -> Option<Box<ContextModel>> {
+        self.last_matched.get(key).map(|entry| {
+            let mut ctx = entry.value().clone();
+            ctx.previous_context = None;
+            Box::new(ctx)
+        })
     }
 
     pub fn record_unmatched(&self, ctx: ContextModel) {
@@ -41,6 +52,7 @@ impl CallTracker {
     pub fn delete_calls_for_route(&self, key: &MatchKey) {
         self.matched
             .retain(|_, ctx| ctx.route_model.match_key != *key);
+        self.last_matched.remove(key);
         info!(route = %key, "Deleted calls for route");
     }
 
@@ -58,6 +70,7 @@ impl CallTracker {
     pub fn reset(&self) {
         self.matched.clear();
         self.unmatched.clear();
+        self.last_matched.clear();
         info!("Call tracker cleared");
     }
 }
@@ -83,6 +96,7 @@ mod tests {
                 match_key: MatchKey::new(verb, pattern),
                 response: ResponseDefinition::default(),
             },
+            previous_context: None,
         }
     }
 
@@ -160,5 +174,54 @@ mod tests {
             .get_calls_for_route(&MatchKey::new("GET", "/a"))
             .is_empty());
         assert!(tracker.get_unmatched().is_empty());
+    }
+
+    #[test]
+    fn get_last_matched_returns_none_when_no_calls() {
+        let tracker = CallTracker::new();
+        assert!(tracker
+            .get_last_matched_for_route(&MatchKey::new("GET", "/a"))
+            .is_none());
+    }
+
+    #[test]
+    fn get_last_matched_returns_context_after_first_call() {
+        let tracker = CallTracker::new();
+        tracker.record_matched(make_ctx("GET", "/a"));
+        assert!(tracker
+            .get_last_matched_for_route(&MatchKey::new("GET", "/a"))
+            .is_some());
+    }
+
+    #[test]
+    fn get_last_matched_nulls_out_previous_context() {
+        let tracker = CallTracker::new();
+        let mut ctx = make_ctx("GET", "/a");
+        ctx.previous_context = Some(Box::new(make_ctx("GET", "/a")));
+        tracker.record_matched(ctx);
+        let result = tracker
+            .get_last_matched_for_route(&MatchKey::new("GET", "/a"))
+            .unwrap();
+        assert!(result.previous_context.is_none());
+    }
+
+    #[test]
+    fn delete_calls_clears_last_matched() {
+        let tracker = CallTracker::new();
+        tracker.record_matched(make_ctx("GET", "/a"));
+        tracker.delete_calls_for_route(&MatchKey::new("GET", "/a"));
+        assert!(tracker
+            .get_last_matched_for_route(&MatchKey::new("GET", "/a"))
+            .is_none());
+    }
+
+    #[test]
+    fn reset_clears_last_matched() {
+        let tracker = CallTracker::new();
+        tracker.record_matched(make_ctx("GET", "/a"));
+        tracker.reset();
+        assert!(tracker
+            .get_last_matched_for_route(&MatchKey::new("GET", "/a"))
+            .is_none());
     }
 }

--- a/playwright/tests/previous-context.spec.ts
+++ b/playwright/tests/previous-context.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, APIRequestContext } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { BamboozleClient, MatchKey, BamboozleAssertBuilder } from '@bamboozle/sdk';
 
 const bamboozleClient: BamboozleClient = new BamboozleClient({ baseUrl: "http://localhost:19090" });
@@ -33,7 +33,7 @@ test('check for previous context', async ({ request }) => {
 });
 
 test('assert state on current req', async ({ request }) => {
-    const key: MatchKey = { verb: 'GET', pattern: 'playwright/check/for/previous/context' };
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/assert/state/on/current/req' };
     deleteState.push(key);
     await bamboozleClient.addRoute({
         match: key,
@@ -48,7 +48,7 @@ test('assert state on current req', async ({ request }) => {
     expect(await bamboozleClient.assert(key.verb, key.pattern, {
         expression: new BamboozleAssertBuilder()
             .with(({ context }) => context.state.equals("1"))
-    }))
+    })).toBeTruthy();
 });
 
 test('use previousContext to trigger 409', async ({ request }) => {

--- a/playwright/tests/prevous-context.spec.ts
+++ b/playwright/tests/prevous-context.spec.ts
@@ -21,9 +21,7 @@ test('check for previous context', async ({ request }) => {
         match: key,
         response: {
             status: "200",
-            content: `
-                    {% if previousContext != null %}OK{% endif %}
-                `
+            content: `{% if previousContext != null %}OK{% endif %}`
         }
     });
     const initReq = await request.get(`http://localhost:18080/${key.pattern}`);
@@ -32,6 +30,7 @@ test('check for previous context', async ({ request }) => {
     const secondReq = await request.get(`http://localhost:18080/${key.pattern}`);
     expect(await secondReq.text()).toEqual("OK");
 });
+
 test('check for no previous previous context', async ({ request }) => {
     const key: MatchKey = { verb: 'GET', pattern: 'playwright/check/for/no/previous/previous/context' };
     deleteState.push(key);
@@ -39,11 +38,11 @@ test('check for no previous previous context', async ({ request }) => {
         match: key,
         response: {
             status: "200",
-            content: `
-                    {% if previousContext.previousContext == null %}OK{% endif %}
-                `
+            content: `{% if previousContext.previousContext != null %}BAD{% endif %}`
         }
     });
+    //these are likely passing because of https://github.com/matt-andrews/Bamboozle/issues/12
+    //once 12 is fixed we can probably do an assertion on real values instead of empty
     const initReq = await request.get(`http://localhost:18080/${key.pattern}`);
     expect(await initReq.text()).toEqual("");
 
@@ -51,5 +50,34 @@ test('check for no previous previous context', async ({ request }) => {
     expect(await secondReq.text()).toEqual("");
 
     const thirdReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await thirdReq.text()).toEqual("");
+});
+
+test('test for state carry forward', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'test/for/state/carry/forward' };
+    deleteState.push(key);
+    await bamboozleClient.addRoute({
+        match: key,
+        response: {
+            status: "200",
+            headers: {
+                "my-state": '{% if previousContext == null %}0{% else %}'
+                    + '{% if previousContext["routeModel"]["response"]["headers"]["my-state"] == null %}0{% else %}'
+                    + '{% assign stateCount = previousContext["routeModel"]["response"]["headers"]["my-state"] %}{{ stateCount }}{% endif %}{% endif %}'
+            },
+            content: `OK`
+        }
+    });
+
+    const initReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await initReq.text()).toEqual("OK");
+    expect(initReq.headers()["my-state"]).toEqual('0');
+
+    const secondReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await secondReq.text()).toEqual("OK");
+    expect(secondReq.headers()["my-state"]).toEqual('1');
+
+    const thirdReq = await request.get(`http://localhost:18080/${key.pattern}`);
     expect(await thirdReq.text()).toEqual("OK");
+    expect(thirdReq.headers()["my-state"]).toEqual('2');
 });

--- a/playwright/tests/prevous-context.spec.ts
+++ b/playwright/tests/prevous-context.spec.ts
@@ -32,6 +32,25 @@ test('check for previous context', async ({ request }) => {
     expect(await secondReq.text()).toEqual("OK");
 });
 
+test('assert state on current req', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/check/for/previous/context' };
+    deleteState.push(key);
+    await bamboozleClient.addRoute({
+        match: key,
+        setState: "{% if previousContext == nil %}1{% else %}{% assign n = previousContext.state | plus: 1 %}{{ n }}{% endif %}",
+        response: {
+            status: "200",
+            content: `{% if previousContext != null %}OK{% endif %}`
+        }
+    });
+    const initReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await initReq.text()).toEqual("");
+    expect(await bamboozleClient.assert(key.verb, key.pattern, {
+        expression: new BamboozleAssertBuilder()
+            .with(({ context }) => context.state.equals("1"))
+    }))
+});
+
 test('use previousContext to trigger 409', async ({ request }) => {
     const key: MatchKey = { verb: 'GET', pattern: 'playwright/use/previous/context/to/trigger/409' };
     deleteState.push(key);

--- a/playwright/tests/prevous-context.spec.ts
+++ b/playwright/tests/prevous-context.spec.ts
@@ -14,6 +14,7 @@ test.afterEach(async () => {
     }
     deleteState = [];
 });
+
 test('check for previous context', async ({ request }) => {
     const key: MatchKey = { verb: 'GET', pattern: 'playwright/check/for/previous/context' };
     deleteState.push(key);
@@ -28,6 +29,25 @@ test('check for previous context', async ({ request }) => {
     expect(await initReq.text()).toEqual("");
 
     const secondReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await secondReq.text()).toEqual("OK");
+});
+
+test('use previousContext to trigger 409', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/use/previous/context/to/trigger/409' };
+    deleteState.push(key);
+    await bamboozleClient.addRoute({
+        match: key,
+        response: {
+            status: "{% if previousContext != null %}409{% else %}200{% endif %}",
+            content: `OK`
+        }
+    });
+    const initReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(initReq.status()).toEqual(200);
+    expect(await initReq.text()).toEqual("OK");
+
+    const secondReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(secondReq.status()).toEqual(409);
     expect(await secondReq.text()).toEqual("OK");
 });
 
@@ -53,17 +73,19 @@ test('check for no previous previous context', async ({ request }) => {
     expect(await thirdReq.text()).toEqual("");
 });
 
+/*
+* Asserts that with previousContext we can carry the state forward through multiple requests
+*/
 test('test for state carry forward', async ({ request }) => {
     const key: MatchKey = { verb: 'GET', pattern: 'test/for/state/carry/forward' };
     deleteState.push(key);
     await bamboozleClient.addRoute({
         match: key,
+        setState: "{% if previousContext == nil %}1{% else %}{% assign n = previousContext.state | plus: 1 %}{{ n }}{% endif %}",
         response: {
             status: "200",
             headers: {
-                "my-state": '{% if previousContext == null %}0{% else %}'
-                    + '{% if previousContext["routeModel"]["response"]["headers"]["my-state"] == null %}0{% else %}'
-                    + '{% assign stateCount = previousContext["routeModel"]["response"]["headers"]["my-state"] %}{{ stateCount }}{% endif %}{% endif %}'
+                "my-state": "{{previousContext.state}}"
             },
             content: `OK`
         }
@@ -71,7 +93,7 @@ test('test for state carry forward', async ({ request }) => {
 
     const initReq = await request.get(`http://localhost:18080/${key.pattern}`);
     expect(await initReq.text()).toEqual("OK");
-    expect(initReq.headers()["my-state"]).toEqual('0');
+    expect(initReq.headers()["my-state"]).toEqual('');
 
     const secondReq = await request.get(`http://localhost:18080/${key.pattern}`);
     expect(await secondReq.text()).toEqual("OK");

--- a/playwright/tests/prevous-context.spec.ts
+++ b/playwright/tests/prevous-context.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import { BamboozleClient, MatchKey, BamboozleAssertBuilder } from '@bamboozle/sdk';
+
+const bamboozleClient: BamboozleClient = new BamboozleClient({ baseUrl: "http://localhost:19090" });
+
+let deleteState: MatchKey[] = [];
+test.afterEach(async () => {
+    for (let key of deleteState) {
+        try {
+            await bamboozleClient.clearCalls(key.verb, key.pattern);
+            await bamboozleClient.deleteRoute(key.verb, key.pattern);
+        }
+        catch { }
+    }
+    deleteState = [];
+});
+test('check for previous context', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/check/for/previous/context' };
+    deleteState.push(key);
+    await bamboozleClient.addRoute({
+        match: key,
+        response: {
+            status: "200",
+            content: `
+                    {% if previousContext != null %}OK{% endif %}
+                `
+        }
+    });
+    const initReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await initReq.text()).toEqual("");
+
+    const secondReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await secondReq.text()).toEqual("OK");
+});
+test('check for no previous previous context', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/check/for/no/previous/previous/context' };
+    deleteState.push(key);
+    await bamboozleClient.addRoute({
+        match: key,
+        response: {
+            status: "200",
+            content: `
+                    {% if previousContext.previousContext == null %}OK{% endif %}
+                `
+        }
+    });
+    const initReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await initReq.text()).toEqual("");
+
+    const secondReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await secondReq.text()).toEqual("");
+
+    const thirdReq = await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await thirdReq.text()).toEqual("OK");
+});

--- a/sdks/npm/src/types.ts
+++ b/sdks/npm/src/types.ts
@@ -15,6 +15,7 @@ export interface ResponseDefinition {
 export interface RouteDefinition {
   match: MatchKey;
   response: ResponseDefinition;
+  setState?: string;
 }
 
 export interface ContextModel {


### PR DESCRIPTION
closes #14 
This PR adds some functionality for limited state management.

- a tracked context contains the `previousContext` property, which is the previous matching context
- route definitions have a new `setState` property, which is LT compatible
- context has a new `state` property which is the rendered version of the above `setState`. This allows you to check the `previousContext.state` during subsequent LT renders