### PR TITLE
feat: fault simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,68 @@ Set `"loopback": true` on a response to echo the full request body back as the r
 }
 ```
 
+## Fault & latency simulation
+
+Add a `simulation` object to any route to inject artificial delay or failure. Routes without a `simulation` field behave normally.
+
+### Delay
+
+Three distributions are available:
+
+| Type | Fields | Behaviour |
+| ------ | ------- | --------- |
+| `fixed` | `ms` | Always delays by exactly `ms` milliseconds — fully deterministic |
+| `random` | `minMs`, `maxMs` | Uniform random delay in the range `[minMs, maxMs]` |
+| `gaussian` | `meanMs`, `stdDevMs` | Normally-distributed delay centred on `meanMs`; clamped to 0 |
+
+```json
+{
+  "match": { "verb": "GET", "pattern": "/orders" },
+  "response": { "status": "200", "content": "[]" },
+  "simulation": {
+    "delay": { "type": "random", "minMs": 100, "maxMs": 800 }
+  }
+}
+```
+
+Delay is implemented with `tokio::time::sleep` — the waiting task yields back to the executor, so other routes are served concurrently and no threads are blocked.
+
+### Faults
+
+Two fault modes are supported:
+
+| Type | Behaviour |
+| ------ | --------- |
+| `connectionReset` | Sends response headers then abruptly closes the connection — client sees a broken-pipe / connection-reset error |
+| `emptyResponse` | Returns `200 OK` with an empty body |
+
+```json
+{
+  "match": { "verb": "POST", "pattern": "/payments" },
+  "response": { "status": "200" },
+  "simulation": {
+    "fault": { "type": "connectionReset", "probability": 0.1 }
+  }
+}
+```
+
+`probability` is a float from `0.0` (never) to `1.0` (always, the default). Values less than 1.0 make the fault **transient** — useful for chaos-style testing where only a fraction of calls should fail.
+
+### Combining delay and fault
+
+Both fields may be set together. When both are present, the delay is always applied first, then the fault check runs — so you can simulate "slow then broken" scenarios:
+
+```json
+{
+  "match": { "verb": "GET", "pattern": "/slow-and-flaky" },
+  "response": { "status": "200", "content": "ok" },
+  "simulation": {
+    "delay": { "type": "gaussian", "meanMs": 300, "stdDevMs": 80 },
+    "fault": { "type": "emptyResponse", "probability": 0.25 }
+  }
+}
+```
+
 ## Route management
 
 | Method | Path | Description |
@@ -250,8 +312,6 @@ Scalar API reference is available at `http://localhost:9090/` when the container
 Bamboozle is built against a detailed design specification. The following capabilities are planned but not yet implemented:
 
 - **Request matching on content** — match routes based on headers, query parameters, and request body (JSON path conditions and schema validation), in addition to verb and path
-- **Delay simulation** — configurable fixed, random, and gaussian latency to test client timeout handling and retry behaviour
-- **Fault simulation** — connection reset and empty response injection to test client resilience against network failures
 - **Session isolation** — per-test namespace via a session header, enabling safe parallel test execution against a shared Bamboozle instance
 - **Route lifecycle options** — `times` to auto-deactivate a route after N matches, and `ttl` to auto-deactivate after N seconds
 - **Richer assertions** — structured assertion types including `calledAtLeast`, `calledAtMost`, `neverCalled`, and per-call body and header verification

--- a/bamboozle/Cargo.lock
+++ b/bamboozle/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,7 +108,10 @@ dependencies = [
  "dashmap",
  "evalexpr",
  "form_urlencoded",
+ "futures",
  "liquid",
+ "rand",
+ "rand_distr",
  "regex",
  "serde",
  "serde_json",
@@ -252,12 +261,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -265,6 +290,40 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -278,8 +337,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -292,6 +356,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -486,6 +561,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "liquid"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +689,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +789,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +830,46 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1207,7 +1347,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1434,6 +1574,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/bamboozle/Cargo.toml
+++ b/bamboozle/Cargo.toml
@@ -25,6 +25,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 utoipa = { version = "5", features = ["axum_extras"] }
 form_urlencoded = "1"
 evalexpr = "13"
+rand = "0.8"
+rand_distr = "0.4"
+futures = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/bamboozle/src/control/mod.rs
+++ b/bamboozle/src/control/mod.rs
@@ -13,6 +13,7 @@ use crate::{
         context::ContextModel,
         match_key::MatchKey,
         route::{ResponseDefinition, RouteDefinition},
+        simulation::{DelayConfig, FaultConfig, FaultKind, SimulationConfig},
     },
 };
 
@@ -40,6 +41,10 @@ pub mod handlers;
             RouteDefinition,
             ResponseDefinition,
             ContextModel,
+            SimulationConfig,
+            DelayConfig,
+            FaultConfig,
+            FaultKind,
             handlers::AssertRequest,
         )
     ),

--- a/bamboozle/src/expression.rs
+++ b/bamboozle/src/expression.rs
@@ -162,6 +162,7 @@ mod tests {
             route_model: RouteDefinition {
                 match_key: MatchKey::new("GET", "/test"),
                 set_state: None,
+                simulation: None,
                 response: ResponseDefinition::default(),
             },
             previous_context: None,

--- a/bamboozle/src/liquid_render.rs
+++ b/bamboozle/src/liquid_render.rs
@@ -136,6 +136,7 @@ mod tests {
             route_model: RouteDefinition {
                 match_key: MatchKey::new("GET", "/test"),
                 set_state: None,
+                simulation: None,
                 response: ResponseDefinition::default(),
             },
             previous_context: None,

--- a/bamboozle/src/mock_server.rs
+++ b/bamboozle/src/mock_server.rs
@@ -1,11 +1,12 @@
 use axum::{
-    body::Bytes,
+    body::{Body, Bytes},
     extract::State,
     http::{HeaderMap, Method, StatusCode, Uri},
     response::{IntoResponse, Response},
     Router,
 };
-use std::collections::HashMap;
+use futures::stream;
+use std::{collections::HashMap, time::Duration};
 
 use crate::{
     app_state::AppState,
@@ -13,6 +14,7 @@ use crate::{
         context::ContextModel,
         match_key::MatchKey,
         route::{ResponseDefinition, RouteDefinition},
+        simulation::FaultKind,
     },
 };
 
@@ -67,6 +69,7 @@ async fn catch_all(
                 route_model: RouteDefinition {
                     match_key: MatchKey::new(verb, path),
                     set_state: None,
+                    simulation: None,
                     response: ResponseDefinition::default(),
                 },
                 state: String::new(),
@@ -96,6 +99,38 @@ async fn catch_all(
             }
 
             state.tracker.record_matched(ctx.clone());
+
+            if let Some(sim) = &route_def.simulation {
+                if let Some(delay) = &sim.delay {
+                    tokio::time::sleep(Duration::from_millis(delay.sample_ms())).await;
+                }
+                if let Some(fault) = &sim.fault {
+                    if fault.should_trigger() {
+                        return match &fault.kind {
+                            FaultKind::ConnectionReset => {
+                                let body = Body::from_stream(stream::once(std::future::ready(
+                                    Err::<Bytes, std::io::Error>(std::io::Error::new(
+                                        std::io::ErrorKind::ConnectionReset,
+                                        "simulated connection reset",
+                                    )),
+                                )));
+                                Response::builder()
+                                    .status(200)
+                                    .body(body)
+                                    .unwrap_or_else(|_| {
+                                        StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                                    })
+                            }
+                            FaultKind::EmptyResponse => Response::builder()
+                                .status(200)
+                                .body(Body::empty())
+                                .unwrap_or_else(|_| {
+                                    StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                                }),
+                        };
+                    }
+                }
+            }
 
             let status_str =
                 state
@@ -150,6 +185,7 @@ mod tests {
         RouteDefinition {
             match_key: MatchKey::new(verb, pattern),
             set_state: None,
+            simulation: None,
             response: ResponseDefinition {
                 status: status.to_string(),
                 content: content.map(|s| s.to_string()),
@@ -256,6 +292,7 @@ mod tests {
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("POST", "/echo"),
                 set_state: None,
+                simulation: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     loopback: Some(true),
@@ -314,6 +351,7 @@ mod tests {
                     pattern: "/thing/{thingName}/{thingVersion}".to_string(),
                 },
                 set_state: None,
+                simulation: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some(r#"{"id":"{{ routeValues.thingName }}"}"#.to_string()),
@@ -438,6 +476,7 @@ mod tests {
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("GET", "/stateful"),
                 set_state: Some("hello-state".to_string()),
+                simulation: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some("{{ state }}".to_string()),
@@ -471,6 +510,7 @@ mod tests {
                     "{% if previousContext == nil %}0{% else %}{{ previousContext.state }}{% endif %}"
                         .to_string(),
                 ),
+                simulation: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some("{{ state }}".to_string()),
@@ -489,5 +529,196 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(body_string(response.into_body()).await, "0");
+    }
+
+    #[tokio::test]
+    async fn simulation_none_has_no_effect() {
+        let state = AppState::new();
+        state
+            .store
+            .set_route(make_route("GET", "/plain", Some("ok"), "200"))
+            .unwrap();
+        let response = router(state)
+            .oneshot(Request::builder().uri("/plain").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_string(response.into_body()).await, "ok");
+    }
+
+    #[tokio::test]
+    async fn fixed_delay_applies() {
+        use crate::models::simulation::{DelayConfig, SimulationConfig};
+        use std::time::Instant;
+
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/slow"),
+                set_state: None,
+                simulation: Some(SimulationConfig {
+                    delay: Some(DelayConfig::Fixed { ms: 50 }),
+                    fault: None,
+                }),
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    content: Some("ok".to_string()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        let start = Instant::now();
+        router(state)
+            .oneshot(Request::builder().uri("/slow").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert!(start.elapsed() >= Duration::from_millis(50));
+    }
+
+    #[tokio::test]
+    async fn fault_empty_response_returns_200_empty_body() {
+        use crate::models::simulation::{FaultConfig, FaultKind, SimulationConfig};
+
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/empty-fault"),
+                set_state: None,
+                simulation: Some(SimulationConfig {
+                    delay: None,
+                    fault: Some(FaultConfig {
+                        kind: FaultKind::EmptyResponse,
+                        probability: 1.0,
+                    }),
+                }),
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    content: Some("should not appear".to_string()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/empty-fault")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_string(response.into_body()).await, "");
+    }
+
+    #[tokio::test]
+    async fn fault_connection_reset_errors_on_body_read() {
+        use crate::models::simulation::{FaultConfig, FaultKind, SimulationConfig};
+
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/reset-fault"),
+                set_state: None,
+                simulation: Some(SimulationConfig {
+                    delay: None,
+                    fault: Some(FaultConfig {
+                        kind: FaultKind::ConnectionReset,
+                        probability: 1.0,
+                    }),
+                }),
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    content: Some("should not appear".to_string()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/reset-fault")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let result = axum::body::to_bytes(response.into_body(), usize::MAX).await;
+        assert!(result.is_err(), "body read should error for connection reset");
+    }
+
+    #[tokio::test]
+    async fn fault_probability_zero_never_triggers() {
+        use crate::models::simulation::{FaultConfig, FaultKind, SimulationConfig};
+
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/no-fault"),
+                set_state: None,
+                simulation: Some(SimulationConfig {
+                    delay: None,
+                    fault: Some(FaultConfig {
+                        kind: FaultKind::EmptyResponse,
+                        probability: 0.0,
+                    }),
+                }),
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    content: Some("normal".to_string()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        for _ in 0..10 {
+            let response = router(state.clone())
+                .oneshot(Request::builder().uri("/no-fault").body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(body_string(response.into_body()).await, "normal");
+        }
+    }
+
+    #[tokio::test]
+    async fn fault_probability_one_always_triggers() {
+        use crate::models::simulation::{FaultConfig, FaultKind, SimulationConfig};
+
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/always-fault"),
+                set_state: None,
+                simulation: Some(SimulationConfig {
+                    delay: None,
+                    fault: Some(FaultConfig {
+                        kind: FaultKind::EmptyResponse,
+                        probability: 1.0,
+                    }),
+                }),
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    content: Some("should not appear".to_string()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        for _ in 0..5 {
+            let response = router(state.clone())
+                .oneshot(
+                    Request::builder()
+                        .uri("/always-fault")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(body_string(response.into_body()).await, "");
+        }
     }
 }

--- a/bamboozle/src/models/mod.rs
+++ b/bamboozle/src/models/mod.rs
@@ -2,3 +2,4 @@ pub mod config_file;
 pub mod context;
 pub mod match_key;
 pub mod route;
+pub mod simulation;

--- a/bamboozle/src/models/route.rs
+++ b/bamboozle/src/models/route.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use utoipa::ToSchema;
 
-use super::match_key::MatchKey;
+use super::{match_key::MatchKey, simulation::SimulationConfig};
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RouteDefinition {
@@ -12,6 +12,8 @@ pub struct RouteDefinition {
     pub response: ResponseDefinition,
     #[serde(rename = "setState", default, skip_serializing_if = "Option::is_none")]
     pub set_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub simulation: Option<SimulationConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]

--- a/bamboozle/src/models/simulation.rs
+++ b/bamboozle/src/models/simulation.rs
@@ -34,9 +34,17 @@ impl DelayConfig {
         match self {
             Self::Fixed { ms } => *ms,
             Self::Random { min_ms, max_ms } => {
-                rand::thread_rng().gen_range(*min_ms..=*max_ms)
+                let (start, end) = if min_ms <= max_ms {
+                    (*min_ms, *max_ms)
+                } else {
+                    (*max_ms, *min_ms)
+                };
+                rand::thread_rng().gen_range(start..=end)
             }
-            Self::Gaussian { mean_ms, std_dev_ms } => Normal::new(*mean_ms, *std_dev_ms)
+            Self::Gaussian {
+                mean_ms,
+                std_dev_ms,
+            } => Normal::new(*mean_ms, *std_dev_ms)
                 .map(|dist| dist.sample(&mut rand::thread_rng()).max(0.0) as u64)
                 .unwrap_or(*mean_ms as u64),
         }

--- a/bamboozle/src/models/simulation.rs
+++ b/bamboozle/src/models/simulation.rs
@@ -1,0 +1,75 @@
+use rand::Rng;
+use rand_distr::{Distribution, Normal};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SimulationConfig {
+    pub delay: Option<DelayConfig>,
+    pub fault: Option<FaultConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum DelayConfig {
+    Fixed {
+        ms: u64,
+    },
+    Random {
+        #[serde(rename = "minMs")]
+        min_ms: u64,
+        #[serde(rename = "maxMs")]
+        max_ms: u64,
+    },
+    Gaussian {
+        #[serde(rename = "meanMs")]
+        mean_ms: f64,
+        #[serde(rename = "stdDevMs")]
+        std_dev_ms: f64,
+    },
+}
+
+impl DelayConfig {
+    pub fn sample_ms(&self) -> u64 {
+        match self {
+            Self::Fixed { ms } => *ms,
+            Self::Random { min_ms, max_ms } => {
+                rand::thread_rng().gen_range(*min_ms..=*max_ms)
+            }
+            Self::Gaussian { mean_ms, std_dev_ms } => Normal::new(*mean_ms, *std_dev_ms)
+                .map(|dist| dist.sample(&mut rand::thread_rng()).max(0.0) as u64)
+                .unwrap_or(*mean_ms as u64),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct FaultConfig {
+    #[serde(rename = "type")]
+    pub kind: FaultKind,
+    #[serde(default = "default_probability")]
+    pub probability: f64,
+}
+
+impl FaultConfig {
+    pub fn should_trigger(&self) -> bool {
+        if self.probability >= 1.0 {
+            true
+        } else if self.probability <= 0.0 {
+            false
+        } else {
+            rand::thread_rng().gen_bool(self.probability)
+        }
+    }
+}
+
+fn default_probability() -> f64 {
+    1.0
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum FaultKind {
+    ConnectionReset,
+    EmptyResponse,
+}

--- a/bamboozle/src/routing/store.rs
+++ b/bamboozle/src/routing/store.rs
@@ -158,6 +158,7 @@ mod tests {
         RouteDefinition {
             match_key: MatchKey::new(verb, pattern),
             set_state: None,
+            simulation: None,
             response: ResponseDefinition::default(),
         }
     }

--- a/bamboozle/src/tracking/tracker.rs
+++ b/bamboozle/src/tracking/tracker.rs
@@ -96,6 +96,7 @@ mod tests {
             route_model: RouteDefinition {
                 match_key: MatchKey::new(verb, pattern),
                 set_state: None,
+                simulation: None,
                 response: ResponseDefinition::default(),
             },
             previous_context: None,

--- a/playwright/tests/simulation.spec.ts
+++ b/playwright/tests/simulation.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test';
+import { BamboozleClient, MatchKey } from '@bamboozle/sdk';
+
+const bamboozleClient = new BamboozleClient({ baseUrl: 'http://localhost:19090' });
+
+function makeKey(suffix: string): MatchKey {
+    return { verb: 'GET', pattern: `playwright/simulation/${suffix}` };
+}
+
+async function cleanup(keys: MatchKey[]) {
+    for (const key of keys) {
+        try { await bamboozleClient.clearCalls(key.verb, key.pattern); } catch { }
+        try { await bamboozleClient.deleteRoute(key.verb, key.pattern); } catch { }
+    }
+}
+
+test.describe('fixed delay', () => {
+    const keys: MatchKey[] = [];
+    test.afterEach(() => cleanup(keys));
+
+    test('response is delayed by at least the configured milliseconds', async ({ request }) => {
+        const key = makeKey('fixed-delay');
+        keys.push(key);
+
+        await bamboozleClient.addRoute({
+            match: key,
+            response: { status: '200', content: 'ok' },
+            simulation: { delay: { type: 'fixed', ms: 200 } },
+        });
+
+        const start = Date.now();
+        const response = await request.get(`http://localhost:18080/${key.pattern}`);
+        const elapsed = Date.now() - start;
+
+        expect(response.status()).toBe(200);
+        expect(elapsed).toBeGreaterThanOrEqual(200);
+    });
+});
+
+test.describe('random delay', () => {
+    const keys: MatchKey[] = [];
+    test.afterEach(() => cleanup(keys));
+
+    test('response is delayed within the configured range', async ({ request }) => {
+        const key = makeKey('random-delay');
+        keys.push(key);
+
+        await bamboozleClient.addRoute({
+            match: key,
+            response: { status: '200', content: 'ok' },
+            simulation: { delay: { type: 'random', minMs: 100, maxMs: 400 } },
+        });
+
+        const start = Date.now();
+        const response = await request.get(`http://localhost:18080/${key.pattern}`);
+        const elapsed = Date.now() - start;
+
+        expect(response.status()).toBe(200);
+        expect(elapsed).toBeGreaterThanOrEqual(100);
+    });
+});
+
+test.describe('emptyResponse fault', () => {
+    const keys: MatchKey[] = [];
+    test.afterEach(() => cleanup(keys));
+
+    test('always returns 200 with empty body when probability is 1', async ({ request }) => {
+        const key = makeKey('empty-response-always');
+        keys.push(key);
+
+        await bamboozleClient.addRoute({
+            match: key,
+            response: { status: '200', content: 'this should not appear' },
+            simulation: { fault: { type: 'emptyResponse', probability: 1.0 } },
+        });
+
+        const response = await request.get(`http://localhost:18080/${key.pattern}`);
+        expect(response.status()).toBe(200);
+        expect(await response.text()).toBe('');
+    });
+
+    test('never triggers when probability is 0', async ({ request }) => {
+        const key = makeKey('empty-response-never');
+        keys.push(key);
+
+        await bamboozleClient.addRoute({
+            match: key,
+            response: { status: '200', content: 'normal response' },
+            simulation: { fault: { type: 'emptyResponse', probability: 0.0 } },
+        });
+
+        for (let i = 0; i < 5; i++) {
+            const response = await request.get(`http://localhost:18080/${key.pattern}`);
+            expect(await response.text()).toBe('normal response');
+        }
+    });
+});
+
+test.describe('connectionReset fault', () => {
+    const keys: MatchKey[] = [];
+    test.afterEach(() => cleanup(keys));
+
+    test('aborts the connection — body is empty or request throws', async ({ request }) => {
+        const key = makeKey('connection-reset');
+        keys.push(key);
+
+        await bamboozleClient.addRoute({
+            match: key,
+            response: { status: '200', content: 'this should not appear' },
+            simulation: { fault: { type: 'connectionReset', probability: 1.0 } },
+        });
+
+        let bodyText = '';
+        try {
+            const response = await request.get(`http://localhost:18080/${key.pattern}`);
+            bodyText = await response.text();
+        } catch {
+            // connection was reset before or during body read — expected
+        }
+
+        expect(bodyText).toBe('');
+    });
+});
+
+test.describe('delay combined with fault', () => {
+    const keys: MatchKey[] = [];
+    test.afterEach(() => cleanup(keys));
+
+    test('delay applies before the fault triggers', async ({ request }) => {
+        const key = makeKey('delay-and-fault');
+        keys.push(key);
+
+        await bamboozleClient.addRoute({
+            match: key,
+            response: { status: '200', content: 'this should not appear' },
+            simulation: {
+                delay: { type: 'fixed', ms: 150 },
+                fault: { type: 'emptyResponse', probability: 1.0 },
+            },
+        });
+
+        const start = Date.now();
+        const response = await request.get(`http://localhost:18080/${key.pattern}`);
+        const elapsed = Date.now() - start;
+
+        expect(response.status()).toBe(200);
+        expect(await response.text()).toBe('');
+        expect(elapsed).toBeGreaterThanOrEqual(150);
+    });
+});
+
+test.describe('calls are recorded even when fault triggers', () => {
+    const keys: MatchKey[] = [];
+    test.afterEach(() => cleanup(keys));
+
+    test('faulted requests appear in call history', async ({ request }) => {
+        const key = makeKey('fault-recorded');
+        keys.push(key);
+
+        await bamboozleClient.addRoute({
+            match: key,
+            response: { status: '200', content: 'ok' },
+            simulation: { fault: { type: 'emptyResponse', probability: 1.0 } },
+        });
+
+        await request.get(`http://localhost:18080/${key.pattern}`);
+        await request.get(`http://localhost:18080/${key.pattern}`);
+
+        expect(await bamboozleClient.assert(key.verb, key.pattern, { expect: 2 })).toBeTruthy();
+    });
+});

--- a/playwright/tests/simulation.spec.ts
+++ b/playwright/tests/simulation.spec.ts
@@ -57,6 +57,7 @@ test.describe('random delay', () => {
 
         expect(response.status()).toBe(200);
         expect(elapsed).toBeGreaterThanOrEqual(100);
+        expect(elapsed).toBeLessThanOrEqual(500);//nudge a little higher to account for true bandwith
     });
 });
 

--- a/scripts/load.sh
+++ b/scripts/load.sh
@@ -6,4 +6,11 @@ MSYS_NO_PATHCONV=1 docker run --rm \
   -e BASE_URL=http://host.docker.internal:18080 \
   grafana/k6:0.57.0 run --no-color /scripts/load-test.js
 
+echo "running simulation isolation test..."
+MSYS_NO_PATHCONV=1 docker run --rm \
+  -v "$(pwd)/perf-test/k6:/scripts" \
+  -e BASE_URL=http://host.docker.internal:18080 \
+  -e CONTROL_URL=http://host.docker.internal:19090 \
+  grafana/k6:0.57.0 run --no-color /scripts/simulation-isolation-test.js
+
 docker compose -f docker-compose.dev.yml down

--- a/scripts/perf-test/k6/simulation-isolation-test.js
+++ b/scripts/perf-test/k6/simulation-isolation-test.js
@@ -1,0 +1,108 @@
+/**
+ * Simulation isolation test.
+ *
+ * Verifies that a route configured with a long fixed delay does not bleed
+ * latency into an unrelated route running concurrently on the same server.
+ *
+ * How it works:
+ *   - "slow" route: 300 ms fixed delay, hammered by SLOW_VUS virtual users
+ *   - "fast" route: no simulation, hammered by FAST_VUS virtual users in parallel
+ *
+ * Both scenarios run for the full duration simultaneously. If tokio's async
+ * sleep bleeds into other tasks the fast route's p95 will creep toward DELAY_MS.
+ * The threshold enforces that it stays well below it.
+ */
+
+import http from 'k6/http';
+import { check, group } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+
+const CONTROL_URL = __ENV.CONTROL_URL || 'http://localhost:19090';
+const BASE_URL     = __ENV.BASE_URL    || 'http://localhost:18080';
+
+const SLOW_PATTERN = 'k6/simulation/slow';
+const FAST_PATTERN = 'k6/simulation/fast';
+const DELAY_MS     = 300;
+const SLOW_VUS     = 5;
+const FAST_VUS     = 5;
+
+const fastDuration = new Trend('sim_fast_duration_ms', true);
+const fastErrors   = new Rate('sim_fast_errors');
+const slowErrors   = new Rate('sim_slow_errors');
+
+export const options = {
+  scenarios: {
+    slow_route_load: {
+      executor: 'constant-vus',
+      vus:      SLOW_VUS,
+      duration: '20s',
+      exec:     'testSlowRoute',
+    },
+    fast_route_isolation: {
+      executor: 'constant-vus',
+      vus:      FAST_VUS,
+      duration: '20s',
+      exec:     'testFastRoute',
+    },
+  },
+  thresholds: {
+    // Fast route must not be affected by the slow route's delay.
+    // p95 must stay well below DELAY_MS even while slow VUs are sleeping.
+    'sim_fast_duration_ms': [`p(95)<${Math.floor(DELAY_MS / 3)}`],
+    'sim_fast_errors':      ['rate<0.01'],
+    'sim_slow_errors':      ['rate<0.01'],
+  },
+};
+
+export function setup() {
+  const headers = { 'Content-Type': 'application/json' };
+
+  const slowRes = http.put(
+    `${CONTROL_URL}/control/routes`,
+    JSON.stringify({
+      match:      { verb: 'GET', pattern: SLOW_PATTERN },
+      response:   { status: '200', content: 'slow' },
+      simulation: { delay: { type: 'fixed', ms: DELAY_MS } },
+    }),
+    { headers },
+  );
+  check(slowRes, { 'slow route registered': (r) => r.status < 300 });
+
+  const fastRes = http.put(
+    `${CONTROL_URL}/control/routes`,
+    JSON.stringify({
+      match:    { verb: 'GET', pattern: FAST_PATTERN },
+      response: { status: '200', content: 'fast' },
+    }),
+    { headers },
+  );
+  check(fastRes, { 'fast route registered': (r) => r.status < 300 });
+}
+
+export function testSlowRoute() {
+  group('slow_route', () => {
+    const res = http.get(`${BASE_URL}/${SLOW_PATTERN}`);
+    const ok = check(res, {
+      'slow: status 200':     (r) => r.status === 200,
+      'slow: delay applied':  (r) => r.timings.duration >= DELAY_MS,
+    });
+    slowErrors.add(!ok);
+  });
+}
+
+export function testFastRoute() {
+  group('fast_route', () => {
+    const res = http.get(`${BASE_URL}/${FAST_PATTERN}`);
+    const ok = check(res, {
+      'fast: status 200':    (r) => r.status === 200,
+      'fast: correct body':  (r) => r.body === 'fast',
+    });
+    fastDuration.add(res.timings.duration);
+    fastErrors.add(!ok);
+  });
+}
+
+export function teardown() {
+  http.del(`${CONTROL_URL}/control/routes/GET/${encodeURIComponent(SLOW_PATTERN)}`);
+  http.del(`${CONTROL_URL}/control/routes/GET/${encodeURIComponent(FAST_PATTERN)}`);
+}

--- a/sdks/npm/src/index.ts
+++ b/sdks/npm/src/index.ts
@@ -4,9 +4,12 @@ export type {
   AssertOptions,
   ClientOptions,
   ContextModel,
+  DelayConfig,
+  FaultConfig,
   MatchKey,
   ResponseDefinition,
   RouteDefinition,
+  SimulationConfig,
 } from "./types.js";
 export {
   BamboozleAssertBuilder,

--- a/sdks/npm/src/types.ts
+++ b/sdks/npm/src/types.ts
@@ -12,10 +12,27 @@ export interface ResponseDefinition {
   loopback?: boolean;
 }
 
+export type DelayConfig =
+  | { type: 'fixed'; ms: number }
+  | { type: 'random'; minMs: number; maxMs: number }
+  | { type: 'gaussian'; meanMs: number; stdDevMs: number };
+
+export interface FaultConfig {
+  type: 'connectionReset' | 'emptyResponse';
+  /** 0.0–1.0. Defaults to 1.0 (always trigger). */
+  probability?: number;
+}
+
+export interface SimulationConfig {
+  delay?: DelayConfig;
+  fault?: FaultConfig;
+}
+
 export interface RouteDefinition {
   match: MatchKey;
   response: ResponseDefinition;
   setState?: string;
+  simulation?: SimulationConfig;
 }
 
 export interface ContextModel {


### PR DESCRIPTION
closes #15 
This PR adds latency/fault simulation to the route definition. This allows users to configure if a route will have delays in the response or chance to drop the connection all together, allowing the user to test fault handling in the SUT.