### PR TITLE
fix: incorrect eval on strongly typed route params

### DIFF
--- a/bamboozle/src/routing/store.rs
+++ b/bamboozle/src/routing/store.rs
@@ -17,12 +17,22 @@ struct StoredRoute {
     definition: RouteDefinition,
     compiled_regex: Regex,
     normalized_pattern: String,
+    param_count: usize,
     constraint_specificity: usize,
 }
 
-/// Counts parameters in `pattern` that carry a specific constraint (anything other
-/// than `:string` or untyped), so the router can prefer e.g. `{id:int}` over
-/// `{id:string}` when both patterns are otherwise equally ranked.
+fn is_narrowing_constraint(constraint: &str) -> bool {
+    matches!(
+        constraint,
+        "int" | "long" | "double" | "decimal" | "float" | "bool" | "guid" | "alpha" | "datetime"
+    )
+}
+
+/// Counts parameters in `pattern` that carry a recognized narrowing constraint
+/// (matching what `regex_gen::constraint_pattern` actually restricts), so the
+/// router can prefer e.g. `{id:int}` over `{id:string}` when both patterns are
+/// otherwise equally ranked. Unknown constraints fall back to `[^/]+` just like
+/// `:string`, so they are not counted.
 fn constraint_specificity(pattern: &str) -> usize {
     let mut count = 0;
     let mut remaining = pattern;
@@ -34,14 +44,21 @@ fn constraint_specificity(pattern: &str) -> usize {
         };
         let inner = rest[1..end].trim_end_matches('?');
         if let Some(colon) = inner.find(':') {
-            let constraint = &inner[colon + 1..];
-            if constraint != "string" {
+            let constraint = inner[colon + 1..].to_ascii_lowercase();
+            if is_narrowing_constraint(&constraint) {
                 count += 1;
             }
         }
         remaining = &remaining[start + end + 1..];
     }
     count
+}
+
+/// Counts `{param}` tokens in `pattern`, used to sort static routes before
+/// parameterized ones. Cached in `StoredRoute` to avoid re-scanning on every
+/// sort during `match_route`.
+fn param_count(pattern: &str) -> usize {
+    pattern.matches('{').count()
 }
 
 pub struct RouteStore {
@@ -92,11 +109,13 @@ impl RouteStore {
         }
 
         let specificity = constraint_specificity(&pattern);
+        let params = param_count(&pattern);
         verb_map.insert(
             lookup_key,
             StoredRoute {
                 definition: def.clone(),
                 compiled_regex: compiled,
+                param_count: params,
                 constraint_specificity: specificity,
                 normalized_pattern: pattern,
             },
@@ -141,9 +160,9 @@ impl RouteStore {
             // specific constraints (e.g. :int) before catch-all ones (e.g. :string);
             // then longer patterns before shorter.
             entries.sort_unstable_by(|a, b| {
-                let a_params = a.value().normalized_pattern.matches('{').count();
-                let b_params = b.value().normalized_pattern.matches('{').count();
-                a_params.cmp(&b_params)
+                a.value()
+                    .param_count
+                    .cmp(&b.value().param_count)
                     .then_with(|| {
                         b.value()
                             .constraint_specificity

--- a/bamboozle/src/routing/store.rs
+++ b/bamboozle/src/routing/store.rs
@@ -17,6 +17,31 @@ struct StoredRoute {
     definition: RouteDefinition,
     compiled_regex: Regex,
     normalized_pattern: String,
+    constraint_specificity: usize,
+}
+
+/// Counts parameters in `pattern` that carry a specific constraint (anything other
+/// than `:string` or untyped), so the router can prefer e.g. `{id:int}` over
+/// `{id:string}` when both patterns are otherwise equally ranked.
+fn constraint_specificity(pattern: &str) -> usize {
+    let mut count = 0;
+    let mut remaining = pattern;
+    while let Some(start) = remaining.find('{') {
+        let rest = &remaining[start..];
+        let end = match rest.find('}') {
+            Some(i) => i,
+            None => break,
+        };
+        let inner = rest[1..end].trim_end_matches('?');
+        if let Some(colon) = inner.find(':') {
+            let constraint = &inner[colon + 1..];
+            if constraint != "string" {
+                count += 1;
+            }
+        }
+        remaining = &remaining[start + end + 1..];
+    }
+    count
 }
 
 pub struct RouteStore {
@@ -66,11 +91,13 @@ impl RouteStore {
             return Err(AppError::AlreadyExists(key_str));
         }
 
+        let specificity = constraint_specificity(&pattern);
         verb_map.insert(
             lookup_key,
             StoredRoute {
                 definition: def.clone(),
                 compiled_regex: compiled,
+                constraint_specificity: specificity,
                 normalized_pattern: pattern,
             },
         );
@@ -110,16 +137,24 @@ impl RouteStore {
     ) -> Option<(RouteDefinition, HashMap<String, String>)> {
         let result = self.routes.get(verb).and_then(|verb_map| {
             let mut entries: Vec<_> = verb_map.iter().collect();
-            // Static routes before parameterized; longer patterns before shorter.
+            // Static routes before parameterized; among equal param counts, more
+            // specific constraints (e.g. :int) before catch-all ones (e.g. :string);
+            // then longer patterns before shorter.
             entries.sort_unstable_by(|a, b| {
                 let a_params = a.value().normalized_pattern.matches('{').count();
                 let b_params = b.value().normalized_pattern.matches('{').count();
-                a_params.cmp(&b_params).then_with(|| {
-                    b.value()
-                        .normalized_pattern
-                        .len()
-                        .cmp(&a.value().normalized_pattern.len())
-                })
+                a_params.cmp(&b_params)
+                    .then_with(|| {
+                        b.value()
+                            .constraint_specificity
+                            .cmp(&a.value().constraint_specificity)
+                    })
+                    .then_with(|| {
+                        b.value()
+                            .normalized_pattern
+                            .len()
+                            .cmp(&a.value().normalized_pattern.len())
+                    })
             });
             entries.iter().find_map(|entry| {
                 let stored = entry.value();
@@ -281,6 +316,40 @@ mod tests {
         store.reset();
         assert!(store.get_all_routes().is_empty());
         assert!(store.match_route("GET", "/a").is_none());
+    }
+
+    #[test]
+    fn typed_int_param_wins_over_string_when_value_is_numeric() {
+        let store = RouteStore::new();
+        store
+            .set_route(make_route("GET", "/items/{id:int}"))
+            .unwrap();
+        store
+            .set_route(make_route("GET", "/items/{id:string}"))
+            .unwrap();
+
+        let (int_def, _) = store.match_route("GET", "/items/42").unwrap();
+        assert!(
+            int_def.match_key.pattern.contains(":int"),
+            "expected :int route to win for numeric value, got {:?}",
+            int_def.match_key.pattern
+        );
+
+        let (str_def, _) = store.match_route("GET", "/items/hello").unwrap();
+        assert!(
+            str_def.match_key.pattern.contains(":string"),
+            "expected :string route to win for non-numeric value, got {:?}",
+            str_def.match_key.pattern
+        );
+    }
+
+    #[test]
+    fn typed_int_param_rejects_non_numeric_with_no_string_fallback() {
+        let store = RouteStore::new();
+        store
+            .set_route(make_route("GET", "/items/{id:int}"))
+            .unwrap();
+        assert!(store.match_route("GET", "/items/abc").is_none());
     }
 
     #[test]

--- a/playwright/tests/response.spec.ts
+++ b/playwright/tests/response.spec.ts
@@ -96,6 +96,67 @@ test.describe('request body loopback should match original', () => {
     }
 });
 
+test.describe('route matching', () => {
+    let deleteState: MatchKey[] = [];
+    test.afterEach(async () => {
+        for (let key of deleteState) {
+            try {
+                await bamboozleClient.clearCalls(key.verb, key.pattern);
+                await bamboozleClient.deleteRoute(key.verb, key.pattern);
+            }
+            catch { }
+        }
+        deleteState = [];
+    });
+    test('route matching with strongly typed route params int with string val', async ({ request }) => {
+        const key1: MatchKey = { verb: 'GET', pattern: 'playwright/route/matching/strong/typed/params/int/on/string/val/{param1:int}' };
+        deleteState.push(key1);
+        await bamboozleClient.addRoute({
+            match: key1,
+            response: {
+                status: "200",
+                headers: {
+                },
+                content: "{{routeValues.param1}}"
+            }
+        });
+        const response1 = await request.get('http://localhost:18080/playwright/route/matching/strong/typed/params/int/on/string/val/24');
+        const response2 = await request.get('http://localhost:18080/playwright/route/matching/strong/typed/params/int/on/string/val/twentyfour');
+
+        expect(await response1.text()).toBe("24");
+        expect(response2.status()).toBe(404);
+    });
+    test('route matching with strongly typed route params int vs string', async ({ request }) => {
+        const key1: MatchKey = { verb: 'GET', pattern: 'playwright/route/matching/strong/typed/params/int/vs/string/{param1:int}' };
+        deleteState.push(key1);
+        await bamboozleClient.addRoute({
+            match: key1,
+            response: {
+                status: "200",
+                headers: {
+                },
+                content: "int: {{routeValues.param1}}"
+            }
+        });
+        const key2: MatchKey = { verb: 'GET', pattern: 'playwright/route/matching/strong/typed/params/int/vs/string/{param1:string}' };
+        deleteState.push(key2);
+        await bamboozleClient.addRoute({
+            match: key2,
+            response: {
+                status: "200",
+                headers: {
+                },
+                content: "string: {{routeValues.param1}}"
+            }
+        });
+        const response1 = await request.get('http://localhost:18080/playwright/route/matching/strong/typed/params/int/vs/string/24');
+        const response2 = await request.get('http://localhost:18080/playwright/route/matching/strong/typed/params/int/vs/string/twentyfour');
+
+        expect(await response1.text()).toBe("int: 24");
+        expect(await response2.text()).toBe("string: twentyfour");
+    });
+})
+
 async function reqFactory(verb: string, location: string, request: APIRequestContext, body: any = {}) {
     if (verb === 'GET') {
         return await request.get(location);

--- a/playwright/tests/response.spec.ts
+++ b/playwright/tests/response.spec.ts
@@ -155,7 +155,7 @@ test.describe('route matching', () => {
         expect(await response1.text()).toBe("int: 24");
         expect(await response2.text()).toBe("string: twentyfour");
     });
-})
+});
 
 async function reqFactory(verb: string, location: string, request: APIRequestContext, body: any = {}) {
     if (verb === 'GET') {


### PR DESCRIPTION
closes #13 
This PR addresses an issue where two identical routes only differing by strong typed route params would fall into the catch all every time regardless of the value.

ex:
- `my/route/{id:int}`
- `my/route/{name;string}`

the `string` variant would always be triggered, even when a number was supplied.

This has been fixed by ordering route priority and addressing the strongly typed route params sooner.