### PR TITLE
feat: expand n-based assertions to be more idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
   [![Image Size](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/matt-andrews/Bamboozle/badges/badge-docker-size.json?v=1&cacheSeconds=3600)](https://github.com/matt-andrews/Bamboozle/pkgs/container/bamboozle)
 </div>
 
-> [!WARNING]
-> This project is still in a super-pre-release state. Use at your own risk.
-
 Bamboozle is a container-native HTTP mock server for integration testing. It intercepts real HTTP traffic, allowing you to test your full client stack — serialisation, authentication headers, retry logic, circuit breakers — without any live dependency.
 
 Unlike in-process mocking libraries, Bamboozle runs as a self-contained Docker container that is fully programmable at runtime from your test code, or configurable from startup files.
@@ -162,8 +159,8 @@ Console and OTLP output are active simultaneously when the endpoint is set, so y
 | Event | Level | Details |
 | ------- | ----- | ------- |
 | Unmatched request | `warn` | Verb, path, and up to 3 fuzzy-matched route suggestions |
-| Assertion failed | `warn` | Expected count, matched count, total calls, expression |
-| Assertion passed | `debug` | Same fields as above |
+| Assertion failed | `warn` | Condition, matched count, total calls, expression |
+| Assertion passed | `debug` | Matched count, expression |
 | Expression error | `debug` | Expression string and the specific evaluation failure |
 | Route registered / deleted | `info` | Route key |
 | Startup | `info` | Listening addresses |
@@ -325,13 +322,22 @@ URL-encode the pattern if it contains path characters — e.g. `orders/{id}` bec
 ### Assert on calls
 
 ```http
-POST http://localhost:9090/control/routes/GET/version/assert?expect=1
+POST http://localhost:9090/control/routes/GET/version/assert?calledExactly=1
 Content-Type: application/json
 
 {}
 ```
 
-`expect` is the required call count. Use `-1` to assert that at least one call was made regardless of count.
+Use query parameters to declare how many times the route (or matching calls) should have been invoked:
+
+| Parameter | Description |
+| ----------- | ------------- |
+| `called_exactly=n` | Pass only if the filtered call count equals exactly `n` |
+| `called_at_least=n` | Pass only if the filtered call count is at least `n` |
+| `called_at_most=n` | Pass only if the filtered call count is at most `n` |
+| `never_called=true` | Pass only if the route was never called (equivalent to `called_exactly=0`) |
+
+When no count parameter is given, the assertion uses a default rule: if an `expression` is provided, at least one matching call must exist; otherwise the assertion always passes.
 
 Returns `200 OK` on pass, `418 I'm a Teapot` on failure, `400 Bad Request` for an invalid expression.
 
@@ -356,8 +362,6 @@ Available expression tokens:
 | `contains(s, sub)` | Substring match |
 | `starts_with(s, prefix)` | Prefix match |
 | `ends_with(s, suffix)` | Suffix match |
-
-> The assertion model is intentionally minimal in the current release. Richer structured conditions — `calledAtLeast`, `calledAtMost`, `neverCalled`, body shape verification, and per-call header checks — are planned.
 
 ### Unmatched calls
 
@@ -389,5 +393,4 @@ Bamboozle is built against a detailed design specification. The following capabi
 - **Request matching on content** — match routes based on headers, query parameters, and request body (JSON path conditions and schema validation), in addition to verb and path
 - **Session isolation** — per-test namespace via a session header, enabling safe parallel test execution against a shared Bamboozle instance
 - **Route lifecycle options** — `times` to auto-deactivate a route after N matches, and `ttl` to auto-deactivate after N seconds
-- **Richer assertions** — structured assertion types including `calledAtLeast`, `calledAtMost`, `neverCalled`, and per-call body and header verification
 - **TestContainers modules** — first-class companion libraries to integrate Bamboozle into test suites with minimal boilerplate

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ URL-encode the pattern if it contains path characters — e.g. `orders/{id}` bec
 ### Assert on calls
 
 ```http
-POST http://localhost:9090/control/routes/GET/version/assert?calledExactly=1
+POST http://localhost:9090/control/routes/GET/version/assert?called_exactly=1
 Content-Type: application/json
 
 {}

--- a/bamboozle/src/control/handlers.rs
+++ b/bamboozle/src/control/handlers.rs
@@ -219,19 +219,55 @@ pub async fn assert_route(
         calls.iter().collect()
     };
 
+    for (name, val) in [
+        ("called_exactly", q.called_exactly),
+        ("called_at_least", q.called_at_least),
+        ("called_at_most", q.called_at_most),
+    ] {
+        if let Some(n) = val {
+            if n < 0 {
+                return Err(AppError::BadRequest(format!("{name} must be >= 0")));
+            }
+        }
+    }
+
     let count = filtered.len() as i64;
-    let (passed, condition) = if q.never_called {
-        (count == 0, format!("expected 0 calls, got {count}"))
-    } else if let Some(n) = q.called_exactly {
-        (count == n, format!("expected exactly {n}, got {count}"))
-    } else if let Some(n) = q.called_at_least {
-        (count >= n, format!("expected at least {n}, got {count}"))
-    } else if let Some(n) = q.called_at_most {
-        (count <= n, format!("expected at most {n}, got {count}"))
+    let any_qualifier = q.never_called
+        || q.called_exactly.is_some()
+        || q.called_at_least.is_some()
+        || q.called_at_most.is_some();
+
+    let mut failing: Vec<String> = Vec::new();
+    if q.never_called && count != 0 {
+        failing.push(format!("expected 0 calls (never_called), got {count}"));
+    }
+    if let Some(n) = q.called_exactly {
+        if count != n {
+            failing.push(format!("expected exactly {n}, got {count}"));
+        }
+    }
+    if let Some(n) = q.called_at_least {
+        if count < n {
+            failing.push(format!("expected at least {n}, got {count}"));
+        }
+    }
+    if let Some(n) = q.called_at_most {
+        if count > n {
+            failing.push(format!("expected at most {n}, got {count}"));
+        }
+    }
+
+    let passed = if any_qualifier {
+        failing.is_empty()
     } else if expr.is_some() {
-        (count >= 1, format!("expected >= 1 match for expression, got {count}"))
+        count >= 1
     } else {
-        (true, String::new())
+        true
+    };
+    let condition = if !passed && !any_qualifier {
+        format!("expected >= 1 match for expression, got {count}")
+    } else {
+        failing.join("; ")
     };
     if passed {
         debug!(

--- a/bamboozle/src/control/handlers.rs
+++ b/bamboozle/src/control/handlers.rs
@@ -157,14 +157,11 @@ pub struct AssertRequest {
 
 #[derive(Deserialize)]
 pub struct AssertQuery {
-    #[serde(default = "AssertQuery::default_expect")]
-    pub expect: i64,
-}
-
-impl AssertQuery {
-    fn default_expect() -> i64 {
-        -1
-    }
+    pub called_exactly: Option<i64>,
+    pub called_at_least: Option<i64>,
+    pub called_at_most: Option<i64>,
+    #[serde(default)]
+    pub never_called: bool,
 }
 
 #[utoipa::path(
@@ -173,7 +170,10 @@ impl AssertQuery {
     params(
         ("verb" = String, Path, description = "HTTP verb"),
         ("pattern" = String, Path, description = "Route pattern (URL-encode slashes as %2F)"),
-        ("expect" = Option<i64>, Query, description = "Expected call count after filtering. -1 (default) accepts any count ≥ 1 when an expression is given, or any count otherwise."),
+        ("called_exactly" = Option<i64>, Query, description = "Assert the filtered call count equals exactly n."),
+        ("called_at_least" = Option<i64>, Query, description = "Assert the filtered call count is at least n."),
+        ("called_at_most" = Option<i64>, Query, description = "Assert the filtered call count is at most n."),
+        ("never_called" = Option<bool>, Query, description = "Assert the route was never called (equivalent to called_exactly=0)."),
     ),
     request_body = AssertRequest,
     responses(
@@ -220,36 +220,34 @@ pub async fn assert_route(
     };
 
     let count = filtered.len() as i64;
-    let passed = if q.expect >= 0 {
-        count == q.expect
+    let (passed, condition) = if q.never_called {
+        (count == 0, format!("expected 0 calls, got {count}"))
+    } else if let Some(n) = q.called_exactly {
+        (count == n, format!("expected exactly {n}, got {count}"))
+    } else if let Some(n) = q.called_at_least {
+        (count >= n, format!("expected at least {n}, got {count}"))
+    } else if let Some(n) = q.called_at_most {
+        (count <= n, format!("expected at most {n}, got {count}"))
     } else if expr.is_some() {
-        // expression given but no explicit expect → require at least one match
-        count >= 1
+        (count >= 1, format!("expected >= 1 match for expression, got {count}"))
     } else {
-        true
+        (true, String::new())
     };
     if passed {
         debug!(
             verb = %match_key.verb,
             pattern = %match_key.pattern,
             matched_count = count,
-            expected = q.expect,
             expression = expr.unwrap_or("<none>"),
             "Assertion passed"
         );
         Ok(StatusCode::OK)
     } else {
-        let condition = if q.expect >= 0 {
-            format!("expected exactly {}, got {}", q.expect, count)
-        } else {
-            format!("expected >= 1 match for expression, got {}", count)
-        };
         warn!(
             verb = %match_key.verb,
             pattern = %match_key.pattern,
             matched_count = count,
             total_calls = calls.len(),
-            expected = q.expect,
             expression = expr.unwrap_or("<none>"),
             condition = %condition,
             "Assertion failed"

--- a/playwright/tests/assert.spec.ts
+++ b/playwright/tests/assert.spec.ts
@@ -315,6 +315,83 @@ test.describe('assert match complex body', () => {
   }
 });
 
+test.describe('assert count qualifiers', () => {
+  let deleteState: MatchKey[] = [];
+  test.afterEach(async () => {
+    for (let key of deleteState) {
+      try {
+        await bamboozleClient.clearCalls(key.verb, key.pattern);
+        await bamboozleClient.deleteRoute(key.verb, key.pattern);
+      }
+      catch { }
+    }
+    deleteState = [];
+  });
+
+  test('calledExactly=1 after 1 call passes', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/assert/count/exactly/pass' };
+    deleteState.push(key);
+    await addRoute(key);
+    await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await bamboozleClient.assert(key.verb, key.pattern, { calledExactly: 1 })).toBeTruthy();
+  });
+
+  test('calledExactly=2 after 1 call fails', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/assert/count/exactly/fail' };
+    deleteState.push(key);
+    await addRoute(key);
+    await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await bamboozleClient.assert(key.verb, key.pattern, { calledExactly: 2 })).toBeFalsy();
+  });
+
+  test('calledAtLeast=1 after 1 call passes', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/assert/count/atleast/pass' };
+    deleteState.push(key);
+    await addRoute(key);
+    await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await bamboozleClient.assert(key.verb, key.pattern, { calledAtLeast: 1 })).toBeTruthy();
+  });
+
+  test('calledAtLeast=2 after 1 call fails', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/assert/count/atleast/fail' };
+    deleteState.push(key);
+    await addRoute(key);
+    await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await bamboozleClient.assert(key.verb, key.pattern, { calledAtLeast: 2 })).toBeFalsy();
+  });
+
+  test('calledAtMost=1 after 1 call passes', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/assert/count/atmost/pass' };
+    deleteState.push(key);
+    await addRoute(key);
+    await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await bamboozleClient.assert(key.verb, key.pattern, { calledAtMost: 1 })).toBeTruthy();
+  });
+
+  test('calledAtMost=0 after 1 call fails', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/assert/count/atmost/fail' };
+    deleteState.push(key);
+    await addRoute(key);
+    await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await bamboozleClient.assert(key.verb, key.pattern, { calledAtMost: 0 })).toBeFalsy();
+  });
+
+  test('neverCalled passes when route has 0 calls', async () => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/assert/count/nevercalled/pass' };
+    deleteState.push(key);
+    await addRoute(key);
+    expect(await bamboozleClient.assert(key.verb, key.pattern, { neverCalled: true })).toBeTruthy();
+  });
+
+  test('neverCalled fails after 1 call', async ({ request }) => {
+    const key: MatchKey = { verb: 'GET', pattern: 'playwright/assert/count/nevercalled/fail' };
+    deleteState.push(key);
+    await addRoute(key);
+    await request.get(`http://localhost:18080/${key.pattern}`);
+    expect(await bamboozleClient.assert(key.verb, key.pattern, { neverCalled: true })).toBeFalsy();
+  });
+});
+
 async function reqFactory(verb: string, location: string, request: APIRequestContext, body: any = {}) {
   if (verb === 'GET') {
     return await request.get(location);

--- a/playwright/tests/response.spec.ts
+++ b/playwright/tests/response.spec.ts
@@ -51,7 +51,7 @@ test.describe('request body can do complex json', () => {
             expect(init).toBeDefined();
             expect(init.hello).toEqual("world");
             expect(init.number).toEqual("24"); //in the LT content we convert to string
-            expect(await bamboozleClient.assert(key.verb, key.pattern, { expect: 1 })).toBeTruthy();
+            expect(await bamboozleClient.assert(key.verb, key.pattern, { calledExactly: 1 })).toBeTruthy();
         });
     }
 });
@@ -91,7 +91,7 @@ test.describe('request body loopback should match original', () => {
             expect(init).toBeDefined();
             expect(init.hello).toEqual("world");
             expect(init.number).toEqual(24);
-            expect(await bamboozleClient.assert(key.verb, key.pattern, { expect: 1 })).toBeTruthy();
+            expect(await bamboozleClient.assert(key.verb, key.pattern, { calledExactly: 1 })).toBeTruthy();
         });
     }
 });

--- a/playwright/tests/simulation.spec.ts
+++ b/playwright/tests/simulation.spec.ts
@@ -167,6 +167,6 @@ test.describe('calls are recorded even when fault triggers', () => {
         await request.get(`http://localhost:18080/${key.pattern}`);
         await request.get(`http://localhost:18080/${key.pattern}`);
 
-        expect(await bamboozleClient.assert(key.verb, key.pattern, { expect: 2 })).toBeTruthy();
+        expect(await bamboozleClient.assert(key.verb, key.pattern, { calledExactly: 2 })).toBeTruthy();
     });
 });

--- a/sdks/npm/src/client.ts
+++ b/sdks/npm/src/client.ts
@@ -42,11 +42,14 @@ export class BamboozleClient {
     const url = new URL(`${this.#baseUrl}${this.#routePath(verb, pattern)}/assert`);
     if (options.neverCalled === true) {
       url.searchParams.set("never_called", "true");
-    } else if (options.calledExactly !== undefined) {
+    }
+    if (options.calledExactly !== undefined) {
       url.searchParams.set("called_exactly", String(options.calledExactly));
-    } else if (options.calledAtLeast !== undefined) {
+    }
+    if (options.calledAtLeast !== undefined) {
       url.searchParams.set("called_at_least", String(options.calledAtLeast));
-    } else if (options.calledAtMost !== undefined) {
+    }
+    if (options.calledAtMost !== undefined) {
       url.searchParams.set("called_at_most", String(options.calledAtMost));
     }
     const body = options.expression !== undefined ? { expression: options.expression.build() } : { expression: "" };

--- a/sdks/npm/src/client.ts
+++ b/sdks/npm/src/client.ts
@@ -40,8 +40,14 @@ export class BamboozleClient {
 
   async assert(verb: string, pattern: string, options: AssertOptions = {}): Promise<boolean> {
     const url = new URL(`${this.#baseUrl}${this.#routePath(verb, pattern)}/assert`);
-    if (options.expect !== undefined) {
-      url.searchParams.set("expect", String(options.expect));
+    if (options.neverCalled === true) {
+      url.searchParams.set("never_called", "true");
+    } else if (options.calledExactly !== undefined) {
+      url.searchParams.set("called_exactly", String(options.calledExactly));
+    } else if (options.calledAtLeast !== undefined) {
+      url.searchParams.set("called_at_least", String(options.calledAtLeast));
+    } else if (options.calledAtMost !== undefined) {
+      url.searchParams.set("called_at_most", String(options.calledAtMost));
     }
     const body = options.expression !== undefined ? { expression: options.expression.build() } : { expression: "" };
 

--- a/sdks/npm/src/types.ts
+++ b/sdks/npm/src/types.ts
@@ -45,8 +45,14 @@ export interface ContextModel {
 export interface AssertOptions {
   /** Boolean evalexpr expression evaluated against each recorded call */
   expression?: IBamboozleAssertBuilder;
-  /** Expected call count. -1 means ≥1 when expression is set, or any count otherwise. Default: -1 */
-  expect?: number;
+  /** Assert the filtered call count equals exactly n */
+  calledExactly?: number;
+  /** Assert the filtered call count is at least n */
+  calledAtLeast?: number;
+  /** Assert the filtered call count is at most n */
+  calledAtMost?: number;
+  /** Assert the route was never called */
+  neverCalled?: boolean;
 }
 
 export interface ClientOptions {


### PR DESCRIPTION
closes #10 
This PR touches on the assertion properties; instead of a single `expect=n` property, we now have a variety of options to choose from:

| Parameter | Description |
| ----------- | ------------- |
| `called_exactly=n` | Pass only if the filtered call count equals exactly `n` |
| `called_at_least=n` | Pass only if the filtered call count is at least `n` |
| `called_at_most=n` | Pass only if the filtered call count is at most `n` |
| `never_called=true` | Pass only if the route was never called (equivalent to `called_exactly=0`) |
