### PR TITLE
feat: automatic response content type

### DIFF
--- a/bamboozle/src/mock_server.rs
+++ b/bamboozle/src/mock_server.rs
@@ -989,12 +989,7 @@ mod tests {
         let state = AppState::new();
         state
             .store
-            .set_route(make_route(
-                "GET",
-                "/data",
-                Some(r#"{"id":1}"#),
-                "200",
-            ))
+            .set_route(make_route("GET", "/data", Some(r#"{"id":1}"#), "200"))
             .unwrap();
         let response = router(state)
             .oneshot(Request::builder().uri("/data").body(Body::empty()).unwrap())
@@ -1109,17 +1104,14 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(
-            content_type_header(&response).as_deref(),
-            Some("text/html")
-        );
+        assert_eq!(content_type_header(&response).as_deref(), Some("text/html"));
     }
 
     #[tokio::test]
     async fn binary_file_png_extension_infers_image_png() {
         let dir = std::env::temp_dir();
         let file_path = dir.join("bamboozle_test_ct.png");
-        std::fs::write(&file_path, &[0x89, 0x50, 0x4E, 0x47]).unwrap();
+        std::fs::write(&file_path, [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
         let state = AppState::new();
         state
@@ -1144,17 +1136,14 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(
-            content_type_header(&response).as_deref(),
-            Some("image/png")
-        );
+        assert_eq!(content_type_header(&response).as_deref(), Some("image/png"));
     }
 
     #[tokio::test]
     async fn binary_file_unknown_extension_infers_octet_stream() {
         let dir = std::env::temp_dir();
         let file_path = dir.join("bamboozle_test_ct.xyz");
-        std::fs::write(&file_path, &[0x00, 0x01, 0x02]).unwrap();
+        std::fs::write(&file_path, [0x00, 0x01, 0x02]).unwrap();
 
         let state = AppState::new();
         state

--- a/bamboozle/src/mock_server.rs
+++ b/bamboozle/src/mock_server.rs
@@ -174,6 +174,42 @@ fn fault_response(kind: &FaultKind) -> Response {
     }
 }
 
+fn infer_content_type_from_path(path: &str, binary: bool) -> &'static str {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    match ext.to_ascii_lowercase().as_str() {
+        "json" => "application/json",
+        "html" | "htm" => "text/html",
+        "xml" => "application/xml",
+        "txt" => "text/plain",
+        "csv" => "text/csv",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "svg" => "image/svg+xml",
+        "webp" => "image/webp",
+        "pdf" => "application/pdf",
+        "zip" => "application/zip",
+        "js" => "application/javascript",
+        "css" => "text/css",
+        _ => {
+            if binary {
+                "application/octet-stream"
+            } else {
+                "text/plain"
+            }
+        }
+    }
+}
+
+fn is_json_content(s: &str) -> bool {
+    let trimmed = s.trim();
+    (trimmed.starts_with('{') || trimmed.starts_with('['))
+        && serde_json::from_str::<serde_json::Value>(trimmed).is_ok()
+}
+
 async fn build_response(
     route_def: &RouteDefinition,
     ctx: &ContextModel,
@@ -182,36 +218,64 @@ async fn build_response(
     let status_str = renderer.render_or_fallback(&route_def.response.status, ctx, "200");
     let status_code: u16 = status_str.trim().parse().unwrap_or(200);
 
-    let body = if route_def.response.loopback {
-        Body::from(ctx.body_raw.clone())
+    let (body, inferred_ct): (Body, Option<String>) = if route_def.response.loopback {
+        let ct = ctx
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+            .map(|(_, v)| v.clone());
+        (Body::from(ctx.body_raw.clone()), ct)
     } else if let Some(path) = &route_def.response.binary_file {
+        let ct = infer_content_type_from_path(path, true).to_string();
         match tokio::fs::File::open(path).await {
-            Ok(file) => Body::from_stream(tokio_util::io::ReaderStream::new(file)),
+            Ok(file) => (
+                Body::from_stream(tokio_util::io::ReaderStream::new(file)),
+                Some(ct),
+            ),
             Err(e) => {
                 tracing::error!(path = %path, error = %e, "Failed to open binary file");
                 return StatusCode::INTERNAL_SERVER_ERROR.into_response();
             }
         }
     } else if let Some(path) = &route_def.response.content_file {
+        let ct = infer_content_type_from_path(path, false).to_string();
         match tokio::fs::read_to_string(path).await {
-            Ok(text) => Body::from(renderer.render_or_fallback(&text, ctx, "")),
+            Ok(text) => (
+                Body::from(renderer.render_or_fallback(&text, ctx, "")),
+                Some(ct),
+            ),
             Err(e) => {
                 tracing::error!(path = %path, error = %e, "Failed to read content file");
                 return StatusCode::INTERNAL_SERVER_ERROR.into_response();
             }
         }
     } else {
-        Body::from(
-            route_def
-                .response
-                .content
-                .as_deref()
-                .map(|t| renderer.render_or_fallback(t, ctx, ""))
-                .unwrap_or_default(),
-        )
+        let text = route_def
+            .response
+            .content
+            .as_deref()
+            .map(|t| renderer.render_or_fallback(t, ctx, ""))
+            .unwrap_or_default();
+        let ct = if is_json_content(&text) {
+            "application/json"
+        } else {
+            "text/plain"
+        };
+        (Body::from(text), Some(ct.to_string()))
     };
 
+    let user_has_ct = route_def
+        .response
+        .headers
+        .keys()
+        .any(|k| k.eq_ignore_ascii_case("content-type"));
+
     let mut builder = Response::builder().status(status_code);
+    if !user_has_ct {
+        if let Some(ct) = inferred_ct {
+            builder = builder.header("content-type", ct);
+        }
+    }
     for (key, val_template) in &route_def.response.headers {
         let val = renderer.render_or_fallback(val_template, ctx, "");
         builder = builder.header(key.as_str(), val.as_str());
@@ -910,5 +974,282 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    fn content_type_header(response: &Response) -> Option<String> {
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+    }
+
+    #[tokio::test]
+    async fn inline_json_content_infers_application_json() {
+        let state = AppState::new();
+        state
+            .store
+            .set_route(make_route(
+                "GET",
+                "/data",
+                Some(r#"{"id":1}"#),
+                "200",
+            ))
+            .unwrap();
+        let response = router(state)
+            .oneshot(Request::builder().uri("/data").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            content_type_header(&response).as_deref(),
+            Some("application/json")
+        );
+    }
+
+    #[tokio::test]
+    async fn inline_json_array_infers_application_json() {
+        let state = AppState::new();
+        state
+            .store
+            .set_route(make_route("GET", "/items", Some(r#"[1,2,3]"#), "200"))
+            .unwrap();
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/items")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            content_type_header(&response).as_deref(),
+            Some("application/json")
+        );
+    }
+
+    #[tokio::test]
+    async fn inline_plain_text_infers_text_plain() {
+        let state = AppState::new();
+        state
+            .store
+            .set_route(make_route("GET", "/msg", Some("hello world"), "200"))
+            .unwrap();
+        let response = router(state)
+            .oneshot(Request::builder().uri("/msg").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            content_type_header(&response).as_deref(),
+            Some("text/plain")
+        );
+    }
+
+    #[tokio::test]
+    async fn content_file_json_extension_infers_application_json() {
+        let dir = std::env::temp_dir();
+        let file_path = dir.join("bamboozle_test_ct.json");
+        std::fs::write(&file_path, r#"{"ok":true}"#).unwrap();
+
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/ct-json"),
+                set_state: None,
+                simulation: None,
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    content_file: Some(file_path.to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/ct-json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            content_type_header(&response).as_deref(),
+            Some("application/json")
+        );
+    }
+
+    #[tokio::test]
+    async fn content_file_html_extension_infers_text_html() {
+        let dir = std::env::temp_dir();
+        let file_path = dir.join("bamboozle_test_ct.html");
+        std::fs::write(&file_path, "<h1>Hello</h1>").unwrap();
+
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/ct-html"),
+                set_state: None,
+                simulation: None,
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    content_file: Some(file_path.to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/ct-html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            content_type_header(&response).as_deref(),
+            Some("text/html")
+        );
+    }
+
+    #[tokio::test]
+    async fn binary_file_png_extension_infers_image_png() {
+        let dir = std::env::temp_dir();
+        let file_path = dir.join("bamboozle_test_ct.png");
+        std::fs::write(&file_path, &[0x89, 0x50, 0x4E, 0x47]).unwrap();
+
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/ct-png"),
+                set_state: None,
+                simulation: None,
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    binary_file: Some(file_path.to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/ct-png")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            content_type_header(&response).as_deref(),
+            Some("image/png")
+        );
+    }
+
+    #[tokio::test]
+    async fn binary_file_unknown_extension_infers_octet_stream() {
+        let dir = std::env::temp_dir();
+        let file_path = dir.join("bamboozle_test_ct.xyz");
+        std::fs::write(&file_path, &[0x00, 0x01, 0x02]).unwrap();
+
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/ct-bin"),
+                set_state: None,
+                simulation: None,
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    binary_file: Some(file_path.to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/ct-bin")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            content_type_header(&response).as_deref(),
+            Some("application/octet-stream")
+        );
+    }
+
+    #[tokio::test]
+    async fn user_specified_content_type_overrides_inferred() {
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/override"),
+                set_state: None,
+                simulation: None,
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    content: Some(r#"{"id":1}"#.to_string()),
+                    headers: HashMap::from([(
+                        "Content-Type".to_string(),
+                        "text/plain".to_string(),
+                    )]),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/override")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            content_type_header(&response).as_deref(),
+            Some("text/plain")
+        );
+    }
+
+    #[tokio::test]
+    async fn loopback_mirrors_request_content_type() {
+        let state = AppState::new();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("POST", "/echo-ct"),
+                set_state: None,
+                simulation: None,
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    loopback: true,
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/echo-ct")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"x":1}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            content_type_header(&response).as_deref(),
+            Some("application/json")
+        );
     }
 }

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -20,7 +20,7 @@
       "name": "@bamboozle/sdk",
       "version": "0.1.0",
       "devDependencies": {
-        "typescript": "^5.4.0"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=18"

--- a/playwright/tests/assert.spec.ts
+++ b/playwright/tests/assert.spec.ts
@@ -426,9 +426,6 @@ async function addRoute(key: MatchKey) {
     match: key,
     response: {
       status: "200",
-      headers: {
-        "Content-Type": "application/json"
-      },
       content: `
         [
           {% for kvp in queryParams %} 

--- a/playwright/tests/file-response.spec.ts
+++ b/playwright/tests/file-response.spec.ts
@@ -30,6 +30,7 @@ test.describe('contentFile serves Liquid-rendered file content', () => {
         expect(response.status()).toBe(200);
         expect(await response.text()).toBe('Hello World!');
         expect(await bamboozleClient.assert(key.verb, key.pattern, { calledExactly: 1 })).toBeTruthy();
+        expect(response.headers()["content-type"]).toBe("text/plain");
     });
 
     test('renders Liquid template from file with different route values', async ({ request }) => {
@@ -46,6 +47,7 @@ test.describe('contentFile serves Liquid-rendered file content', () => {
         const response = await request.get('http://localhost:18080/playwright/file/greeting/alt/Alice');
         expect(response.status()).toBe(200);
         expect(await response.text()).toBe('Hello Alice!');
+        expect(response.headers()["content-type"]).toBe("text/plain");
     });
 });
 
@@ -68,7 +70,6 @@ test.describe('binaryFile serves raw bytes', () => {
             match: key,
             response: {
                 status: '200',
-                headers: { 'Content-Type': 'image/png' },
                 binaryFile: '/test_configs/assets/sample.bin',
             },
         });
@@ -83,6 +84,7 @@ test.describe('binaryFile serves raw bytes', () => {
         expect(body[2]).toBe(0x4e);
         expect(body[3]).toBe(0x47);
         expect(await bamboozleClient.assert(key.verb, key.pattern, { calledExactly: 1 })).toBeTruthy();
+        expect(response.headers()["content-type"]).toBe("application/octet-stream");
     });
 
     test('binary content is not processed as Liquid template', async ({ request }) => {
@@ -101,6 +103,7 @@ test.describe('binaryFile serves raw bytes', () => {
         const body = await response.body();
         // Raw bytes must be returned without modification
         expect(Buffer.from([0x89, 0x50, 0x4e, 0x47]).equals(body)).toBeTruthy();
+        expect(response.headers()["content-type"]).toBe("application/octet-stream");
     });
 });
 

--- a/playwright/tests/response.spec.ts
+++ b/playwright/tests/response.spec.ts
@@ -52,6 +52,7 @@ test.describe('request body can do complex json', () => {
             expect(init.hello).toEqual("world");
             expect(init.number).toEqual("24"); //in the LT content we convert to string
             expect(await bamboozleClient.assert(key.verb, key.pattern, { calledExactly: 1 })).toBeTruthy();
+            expect(initReq.headers()["content-type"]).toBe("application/json");
         });
     }
 });
@@ -77,9 +78,6 @@ test.describe('request body loopback should match original', () => {
                 match: key,
                 response: {
                     status: "200",
-                    headers: {
-                        "Content-Type": "application/json"
-                    },
                     loopback: true
                 }
             });
@@ -92,6 +90,7 @@ test.describe('request body loopback should match original', () => {
             expect(init.hello).toEqual("world");
             expect(init.number).toEqual(24);
             expect(await bamboozleClient.assert(key.verb, key.pattern, { calledExactly: 1 })).toBeTruthy();
+            expect(initReq.headers()["content-type"]).toBe("application/json");
         });
     }
 });
@@ -125,6 +124,7 @@ test.describe('route matching', () => {
 
         expect(await response1.text()).toBe("24");
         expect(response2.status()).toBe(404);
+        expect(response2.headers()["content-type"]).toBe(undefined);
     });
     test('route matching with strongly typed route params int vs string', async ({ request }) => {
         const key1: MatchKey = { verb: 'GET', pattern: 'playwright/route/matching/strong/typed/params/int/vs/string/{param1:int}' };


### PR DESCRIPTION
closes #33 
This PR allows the api to automatically detect the `content-type` and set the header based on the data being returned. This means the `content-type` header no longer needs to be set as part of the route configuration (unless you're doing something that cannot be automatically detected/weird)