### PR TITLE
feat: route management

### DIFF
--- a/bamboozle/src/app_state.rs
+++ b/bamboozle/src/app_state.rs
@@ -10,9 +10,9 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new() -> Self {
+    pub fn new(max_routes: usize, max_content_size: usize) -> Self {
         Self {
-            store: Arc::new(RouteStore::new()),
+            store: Arc::new(RouteStore::new(max_routes, max_content_size)),
             tracker: Arc::new(CallTracker::new()),
             renderer: Arc::new(Renderer::new()),
         }
@@ -21,6 +21,6 @@ impl AppState {
 
 impl Default for AppState {
     fn default() -> Self {
-        Self::new()
+        Self::new(1000, 10 * 1024 * 1024)
     }
 }

--- a/bamboozle/src/config.rs
+++ b/bamboozle/src/config.rs
@@ -23,15 +23,18 @@ impl AppConfig {
             .map(|v| v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
 
-        let max_routes = std::env::var("MAX_ROUTES")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(1000);
-
-        let max_content_size = std::env::var("MAX_CONTENT_SIZE_BYTES")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(10 * 1024 * 1024);
+        let max_routes = match std::env::var("MAX_ROUTES") {
+            Ok(val) => val
+                .parse::<usize>()
+                .context("MAX_ROUTES must be a valid positive integer")?,
+            Err(_) => 1000,
+        };
+        let max_content_size = match std::env::var("MAX_CONTENT_SIZE_BYTES") {
+            Ok(val) => val
+                .parse::<usize>()
+                .context("MAX_CONTENT_SIZE_BYTES must be a valid positive integer")?,
+            Err(_) => 10 * 1024 * 1024,
+        };
 
         #[cfg(feature = "tls")]
         let tls_cert_file = std::env::var("TLS_CERT_FILE").ok();
@@ -40,9 +43,7 @@ impl AppConfig {
 
         #[cfg(feature = "tls")]
         if tls_cert_file.is_some() != tls_key_file.is_some() {
-            anyhow::bail!(
-                "TLS_CERT_FILE and TLS_KEY_FILE must both be set or both be unset"
-            );
+            anyhow::bail!("TLS_CERT_FILE and TLS_KEY_FILE must both be set or both be unset");
         }
 
         Ok(Self {

--- a/bamboozle/src/config.rs
+++ b/bamboozle/src/config.rs
@@ -3,6 +3,8 @@ use anyhow::Context;
 pub struct AppConfig {
     pub route_config_folders: Vec<String>,
     pub throw_on_error: bool,
+    pub max_routes: usize,
+    pub max_content_size: usize,
     #[cfg(feature = "tls")]
     pub tls_cert_file: Option<String>,
     #[cfg(feature = "tls")]
@@ -21,6 +23,16 @@ impl AppConfig {
             .map(|v| v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
 
+        let max_routes = std::env::var("MAX_ROUTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1000);
+
+        let max_content_size = std::env::var("MAX_CONTENT_SIZE_BYTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10 * 1024 * 1024);
+
         #[cfg(feature = "tls")]
         let tls_cert_file = std::env::var("TLS_CERT_FILE").ok();
         #[cfg(feature = "tls")]
@@ -36,6 +48,8 @@ impl AppConfig {
         Ok(Self {
             route_config_folders,
             throw_on_error,
+            max_routes,
+            max_content_size,
             #[cfg(feature = "tls")]
             tls_cert_file,
             #[cfg(feature = "tls")]

--- a/bamboozle/src/control/handlers.rs
+++ b/bamboozle/src/control/handlers.rs
@@ -31,7 +31,9 @@ pub async fn post_routes(
     State(state): State<AppState>,
     Json(route): Json<RouteDefinition>,
 ) -> Result<(StatusCode, Json<RouteDefinition>), AppError> {
+    let match_key = route.match_key.clone();
     let response = state.store.set_route(route)?;
+    state.tracker.delete_calls_for_route(&match_key);
     Ok((StatusCode::CREATED, Json(response)))
 }
 
@@ -51,8 +53,10 @@ pub async fn put_routes(
     Json(route): Json<RouteDefinition>,
 ) -> Result<(StatusCode, Json<RouteDefinition>), AppError> {
     // Ignore NotFound — PUT is idempotent. delete_route normalizes internally.
+    let match_key = route.match_key.clone();
     let _ = state.store.delete_route(&route.match_key);
     let response = state.store.set_route(route)?;
+    state.tracker.delete_calls_for_route(&match_key);
     Ok((StatusCode::CREATED, Json(response)))
 }
 

--- a/bamboozle/src/expression.rs
+++ b/bamboozle/src/expression.rs
@@ -169,6 +169,7 @@ mod tests {
                 match_key: MatchKey::new("GET", "/test"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition::default(),
             },
             previous_context: None,

--- a/bamboozle/src/liquid_render.rs
+++ b/bamboozle/src/liquid_render.rs
@@ -136,6 +136,7 @@ mod tests {
                 match_key: MatchKey::new("GET", "/test"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition::default(),
             },
             previous_context: None,

--- a/bamboozle/src/main.rs
+++ b/bamboozle/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> anyhow::Result<()> {
     init_tracing();
 
     let config = config::AppConfig::from_env()?;
-    let state = app_state::AppState::new();
+    let state = app_state::AppState::new(config.max_routes, config.max_content_size);
 
     config_loader::load(&config, &state).await?;
 

--- a/bamboozle/src/mock_server.rs
+++ b/bamboozle/src/mock_server.rs
@@ -65,6 +65,7 @@ async fn catch_all(
                     match_key: MatchKey::new(verb, path),
                     set_state: None,
                     simulation: None,
+                    max_calls: None,
                     response: ResponseDefinition::default(),
                 },
                 state: String::new(),
@@ -94,6 +95,13 @@ async fn catch_all(
             }
 
             state.tracker.record_matched(ctx.clone());
+
+            if let Some(max_calls) = route_def.max_calls {
+                let calls = state.tracker.get_calls_for_route(&route_def.match_key);
+                if calls.len() >= max_calls {
+                    let _ = state.store.delete_route(&route_def.match_key);
+                }
+            }
 
             if let Some(sim) = &route_def.simulation {
                 if let Some(fault_response) = apply_simulation(sim).await {
@@ -301,6 +309,7 @@ mod tests {
             match_key: MatchKey::new(verb, pattern),
             set_state: None,
             simulation: None,
+            max_calls: None,
             response: ResponseDefinition {
                 status: status.to_string(),
                 content: content.map(|s| s.to_string()),
@@ -323,7 +332,7 @@ mod tests {
 
     #[tokio::test]
     async fn unmatched_route_returns_404() {
-        let app = router(AppState::new());
+        let app = router(AppState::default());
         let response = app
             .oneshot(
                 Request::builder()
@@ -338,7 +347,7 @@ mod tests {
 
     #[tokio::test]
     async fn matched_static_route_returns_200() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route("GET", "/hello", Some("world"), "200"))
@@ -357,7 +366,7 @@ mod tests {
 
     #[tokio::test]
     async fn response_body_matches_configured_content() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route("GET", "/greet", Some("hello there"), "200"))
@@ -376,7 +385,7 @@ mod tests {
 
     #[tokio::test]
     async fn custom_status_code_is_returned() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route("POST", "/things", None, "201"))
@@ -396,13 +405,14 @@ mod tests {
 
     #[tokio::test]
     async fn loopback_echoes_request_body() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("POST", "/echo"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     loopback: true,
@@ -425,7 +435,7 @@ mod tests {
 
     #[tokio::test]
     async fn route_value_rendered_in_response_body() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route(
@@ -452,7 +462,7 @@ mod tests {
         // Construct via MatchKey fields directly (not MatchKey::new) to simulate the
         // serde deserialization path used by config file loading, where param names
         // retain their original case.
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
@@ -462,6 +472,7 @@ mod tests {
                 },
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some(r#"{"id":"{{ routeValues.thingName }}"}"#.to_string()),
@@ -486,7 +497,7 @@ mod tests {
 
     #[tokio::test]
     async fn unmatched_request_is_tracked() {
-        let state = AppState::new();
+        let state = AppState::default();
         let tracker = state.tracker.clone();
         router(state)
             .oneshot(
@@ -502,7 +513,7 @@ mod tests {
 
     #[tokio::test]
     async fn matched_request_is_tracked() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route("GET", "/tracked", Some("ok"), "200"))
@@ -526,8 +537,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn max_calls_auto_deletes_route() {
+        let state = AppState::default();
+        state
+            .store
+            .set_route(RouteDefinition {
+                match_key: MatchKey::new("GET", "/limited"),
+                set_state: None,
+                simulation: None,
+                max_calls: Some(2),
+                response: ResponseDefinition {
+                    status: "200".to_string(),
+                    content: Some("ok".to_string()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+
+        // 1st request -> 200
+        let req1 = router(state.clone())
+            .oneshot(Request::builder().uri("/limited").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(req1.status(), StatusCode::OK);
+
+        // 2nd request -> 200 (hits max_calls and auto-deletes)
+        let req2 = router(state.clone())
+            .oneshot(Request::builder().uri("/limited").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(req2.status(), StatusCode::OK);
+
+        // 3rd request -> 404 (route was deleted)
+        let req3 = router(state)
+            .oneshot(Request::builder().uri("/limited").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(req3.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
     async fn previous_context_is_null_on_first_call() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route("GET", "/thing", Some("ok"), "200"))
@@ -541,7 +592,7 @@ mod tests {
 
     #[tokio::test]
     async fn previous_context_is_set_on_second_call() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route("GET", "/thing", Some("ok"), "200"))
@@ -556,7 +607,7 @@ mod tests {
 
     #[tokio::test]
     async fn previous_context_does_not_nest() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route("GET", "/thing", Some("ok"), "200"))
@@ -577,13 +628,14 @@ mod tests {
 
     #[tokio::test]
     async fn set_state_template_is_rendered_and_stored() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("GET", "/stateful"),
                 set_state: Some("hello-state".to_string()),
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some("{{ state }}".to_string()),
@@ -608,7 +660,7 @@ mod tests {
 
     #[tokio::test]
     async fn previous_context_state_accessible_on_second_call() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
@@ -618,6 +670,7 @@ mod tests {
                         .to_string(),
                 ),
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some("{{ state }}".to_string()),
@@ -640,7 +693,7 @@ mod tests {
 
     #[tokio::test]
     async fn simulation_none_has_no_effect() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route("GET", "/plain", Some("ok"), "200"))
@@ -663,7 +716,7 @@ mod tests {
         use crate::models::simulation::{DelayConfig, SimulationConfig};
         use std::time::Instant;
 
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
@@ -673,6 +726,7 @@ mod tests {
                     delay: Some(DelayConfig::Fixed { ms: 50 }),
                     fault: None,
                 }),
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some("ok".to_string()),
@@ -692,7 +746,7 @@ mod tests {
     async fn fault_empty_response_returns_200_empty_body() {
         use crate::models::simulation::{FaultConfig, FaultKind, SimulationConfig};
 
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
@@ -705,6 +759,7 @@ mod tests {
                         probability: 1.0,
                     }),
                 }),
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some("should not appear".to_string()),
@@ -729,7 +784,7 @@ mod tests {
     async fn fault_connection_reset_errors_on_body_read() {
         use crate::models::simulation::{FaultConfig, FaultKind, SimulationConfig};
 
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
@@ -742,6 +797,7 @@ mod tests {
                         probability: 1.0,
                     }),
                 }),
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some("should not appear".to_string()),
@@ -770,7 +826,7 @@ mod tests {
     async fn fault_probability_zero_never_triggers() {
         use crate::models::simulation::{FaultConfig, FaultKind, SimulationConfig};
 
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
@@ -783,6 +839,7 @@ mod tests {
                         probability: 0.0,
                     }),
                 }),
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some("normal".to_string()),
@@ -808,7 +865,7 @@ mod tests {
     async fn fault_probability_one_always_triggers() {
         use crate::models::simulation::{FaultConfig, FaultKind, SimulationConfig};
 
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
@@ -821,6 +878,7 @@ mod tests {
                         probability: 1.0,
                     }),
                 }),
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some("should not appear".to_string()),
@@ -848,13 +906,14 @@ mod tests {
         let file_path = dir.join("bamboozle_test_content_file.txt");
         std::fs::write(&file_path, "Hello {{ routeValues.name }}!").unwrap();
 
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("GET", "/greet/{name}"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content_file: Some(file_path.to_string_lossy().into_owned()),
@@ -882,13 +941,14 @@ mod tests {
         let expected: Vec<u8> = vec![0x89, 0x50, 0x4E, 0x47];
         std::fs::write(&file_path, &expected).unwrap();
 
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("GET", "/image"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     binary_file: Some(file_path.to_string_lossy().into_owned()),
@@ -914,13 +974,14 @@ mod tests {
 
     #[tokio::test]
     async fn content_file_not_found_returns_500() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("GET", "/missing-text"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content_file: Some("/nonexistent/path/file.txt".to_string()),
@@ -942,13 +1003,14 @@ mod tests {
 
     #[tokio::test]
     async fn binary_file_not_found_returns_500() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("GET", "/missing-binary"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     binary_file: Some("/nonexistent/path/file.bin".to_string()),
@@ -978,7 +1040,7 @@ mod tests {
 
     #[tokio::test]
     async fn inline_json_content_infers_application_json() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route("GET", "/data", Some(r#"{"id":1}"#), "200"))
@@ -995,7 +1057,7 @@ mod tests {
 
     #[tokio::test]
     async fn inline_json_array_infers_application_json() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route("GET", "/items", Some(r#"[1,2,3]"#), "200"))
@@ -1017,7 +1079,7 @@ mod tests {
 
     #[tokio::test]
     async fn inline_plain_text_infers_text_plain() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(make_route("GET", "/msg", Some("hello world"), "200"))
@@ -1038,13 +1100,14 @@ mod tests {
         let file_path = dir.join("bamboozle_test_ct.json");
         std::fs::write(&file_path, r#"{"ok":true}"#).unwrap();
 
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("GET", "/ct-json"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content_file: Some(file_path.to_string_lossy().into_owned()),
@@ -1073,13 +1136,14 @@ mod tests {
         let file_path = dir.join("bamboozle_test_ct.html");
         std::fs::write(&file_path, "<h1>Hello</h1>").unwrap();
 
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("GET", "/ct-html"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content_file: Some(file_path.to_string_lossy().into_owned()),
@@ -1105,13 +1169,14 @@ mod tests {
         let file_path = dir.join("bamboozle_test_ct.png");
         std::fs::write(&file_path, [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("GET", "/ct-png"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     binary_file: Some(file_path.to_string_lossy().into_owned()),
@@ -1137,13 +1202,14 @@ mod tests {
         let file_path = dir.join("bamboozle_test_ct.xyz");
         std::fs::write(&file_path, [0x00, 0x01, 0x02]).unwrap();
 
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("GET", "/ct-bin"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     binary_file: Some(file_path.to_string_lossy().into_owned()),
@@ -1168,13 +1234,14 @@ mod tests {
 
     #[tokio::test]
     async fn user_specified_content_type_overrides_inferred() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("GET", "/override"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some(r#"{"id":1}"#.to_string()),
@@ -1203,13 +1270,14 @@ mod tests {
 
     #[tokio::test]
     async fn body_json_field_rendered_in_response() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("PUT", "/secrets/{name}"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some(r#"{"value":"{{ body.value }}"}"#.to_string()),
@@ -1243,13 +1311,14 @@ mod tests {
     async fn body_json_field_works_without_content_type_header() {
         // Body is always parsed as JSON regardless of Content-Type header.
         // A valid JSON body without a Content-Type header still populates body.*.
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("PUT", "/raw/{name}"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     content: Some(r#"{"value":"{{ body.value }}"}"#.to_string()),
@@ -1276,13 +1345,14 @@ mod tests {
 
     #[tokio::test]
     async fn loopback_mirrors_request_content_type() {
-        let state = AppState::new();
+        let state = AppState::default();
         state
             .store
             .set_route(RouteDefinition {
                 match_key: MatchKey::new("POST", "/echo-ct"),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition {
                     status: "200".to_string(),
                     loopback: true,

--- a/bamboozle/src/mock_server.rs
+++ b/bamboozle/src/mock_server.rs
@@ -97,8 +97,8 @@ async fn catch_all(
             state.tracker.record_matched(ctx.clone());
 
             if let Some(max_calls) = route_def.max_calls {
-                let calls = state.tracker.get_calls_for_route(&route_def.match_key);
-                if calls.len() >= max_calls {
+                let call_count = state.tracker.get_call_count_for_route(&route_def.match_key);
+                if call_count >= max_calls {
                     let _ = state.store.delete_route(&route_def.match_key);
                 }
             }

--- a/bamboozle/src/models/route.rs
+++ b/bamboozle/src/models/route.rs
@@ -14,6 +14,8 @@ pub struct RouteDefinition {
     pub set_state: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub simulation: Option<SimulationConfig>,
+    #[serde(rename = "maxCalls", default, skip_serializing_if = "Option::is_none")]
+    pub max_calls: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]

--- a/bamboozle/src/routing/store.rs
+++ b/bamboozle/src/routing/store.rs
@@ -64,18 +64,24 @@ fn param_count(pattern: &str) -> usize {
 pub struct RouteStore {
     // outer key = uppercase HTTP verb ("GET"), inner key = fully-lowercase normalized pattern
     routes: DashMap<String, DashMap<String, StoredRoute>>,
+    max_routes: usize,
+    max_content_size: usize,
+    route_count: std::sync::atomic::AtomicUsize,
 }
 
 impl Default for RouteStore {
     fn default() -> Self {
-        Self::new()
+        Self::new(1000, 10 * 1024 * 1024)
     }
 }
 
 impl RouteStore {
-    pub fn new() -> Self {
+    pub fn new(max_routes: usize, max_content_size: usize) -> Self {
         Self {
             routes: DashMap::new(),
+            max_routes,
+            max_content_size,
+            route_count: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 
@@ -93,6 +99,16 @@ impl RouteStore {
             return Err(AppError::BadRequest(
                 "Only one of 'content', 'contentFile', 'binaryFile', or 'loopback' may be specified".to_string(),
             ));
+        }
+
+        if let Some(content) = &def.response.content {
+            if content.len() > self.max_content_size {
+                return Err(AppError::BadRequest(format!(
+                    "Content size {} bytes exceeds maximum allowed {} bytes",
+                    content.len(),
+                    self.max_content_size
+                )));
+            }
         }
 
         let verb = def.match_key.verb.trim().to_ascii_uppercase();
@@ -123,6 +139,13 @@ impl RouteStore {
             return Err(AppError::AlreadyExists(key_str));
         }
 
+        if self.route_count.load(std::sync::atomic::Ordering::Relaxed) >= self.max_routes {
+            return Err(AppError::BadRequest(format!(
+                "Maximum number of routes ({}) reached",
+                self.max_routes
+            )));
+        }
+
         let specificity = constraint_specificity(&pattern);
         let params = param_count(&pattern);
         verb_map.insert(
@@ -135,6 +158,7 @@ impl RouteStore {
                 normalized_pattern: pattern,
             },
         );
+        self.route_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         info!(route = %key_str, "Route set");
         Ok(def)
@@ -158,6 +182,7 @@ impl RouteStore {
             return Err(RouteError::NotFound(key_str));
         }
 
+        self.route_count.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
         info!(route = %key_str, "Route deleted");
         Ok(())
     }
@@ -249,6 +274,7 @@ impl RouteStore {
 
     pub fn reset(&self) {
         self.routes.clear();
+        self.route_count.store(0, std::sync::atomic::Ordering::Relaxed);
         info!("Route store cleared");
     }
 }
@@ -269,20 +295,21 @@ mod tests {
             match_key: MatchKey::new(verb, pattern),
             set_state: None,
             simulation: None,
+            max_calls: None,
             response: ResponseDefinition::default(),
         }
     }
 
     #[test]
     fn set_route_and_match_it() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store.set_route(make_route("GET", "/api/users")).unwrap();
         assert!(store.match_route("GET", "/api/users").is_some());
     }
 
     #[test]
     fn duplicate_set_route_returns_already_exists() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store.set_route(make_route("GET", "/api/users")).unwrap();
         let err = store
             .set_route(make_route("GET", "/api/users"))
@@ -292,7 +319,7 @@ mod tests {
 
     #[test]
     fn delete_route_removes_it() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store
             .set_route(make_route("DELETE", "/items/{id}"))
             .unwrap();
@@ -303,7 +330,7 @@ mod tests {
 
     #[test]
     fn delete_nonexistent_route_returns_not_found() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         let err = store
             .delete_route(&MatchKey::new("GET", "/missing"))
             .unwrap_err();
@@ -312,7 +339,7 @@ mod tests {
 
     #[test]
     fn match_static_route() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store.set_route(make_route("GET", "/hello")).unwrap();
         let (def, values) = store.match_route("GET", "/hello").unwrap();
         assert_eq!(def.match_key.pattern, "hello");
@@ -321,7 +348,7 @@ mod tests {
 
     #[test]
     fn match_parameterized_route_extracts_values() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store.set_route(make_route("GET", "/users/{id}")).unwrap();
         let (_, values) = store.match_route("GET", "/users/42").unwrap();
         assert_eq!(values["id"], "42");
@@ -329,7 +356,7 @@ mod tests {
 
     #[test]
     fn match_route_returns_none_for_no_match() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store.set_route(make_route("GET", "/api/users")).unwrap();
         assert!(store.match_route("GET", "/api/orders").is_none());
         assert!(store.match_route("POST", "/api/users").is_none());
@@ -337,7 +364,7 @@ mod tests {
 
     #[test]
     fn get_all_routes_returns_all() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store.set_route(make_route("GET", "/a")).unwrap();
         store.set_route(make_route("POST", "/b")).unwrap();
         assert_eq!(store.get_all_routes().len(), 2);
@@ -345,7 +372,7 @@ mod tests {
 
     #[test]
     fn reset_clears_all_routes() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store.set_route(make_route("GET", "/a")).unwrap();
         store.reset();
         assert!(store.get_all_routes().is_empty());
@@ -354,7 +381,7 @@ mod tests {
 
     #[test]
     fn typed_int_param_wins_over_string_when_value_is_numeric() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store
             .set_route(make_route("GET", "/items/{id:int}"))
             .unwrap();
@@ -379,7 +406,7 @@ mod tests {
 
     #[test]
     fn typed_int_param_rejects_non_numeric_with_no_string_fallback() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store
             .set_route(make_route("GET", "/items/{id:int}"))
             .unwrap();
@@ -388,7 +415,7 @@ mod tests {
 
     #[test]
     fn suggest_routes_returns_similar_route() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store.set_route(make_route("GET", "/api/users")).unwrap();
         store.set_route(make_route("GET", "/api/orders")).unwrap();
         let suggestions = store.suggest_routes("GET", "/api/users");
@@ -402,7 +429,7 @@ mod tests {
 
     #[test]
     fn suggest_routes_boosts_same_verb() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store.set_route(make_route("GET", "/api/users")).unwrap();
         store.set_route(make_route("POST", "/api/users")).unwrap();
         // Same path requested with GET — GET|api/users should rank first due to verb boost.
@@ -417,7 +444,7 @@ mod tests {
 
     #[test]
     fn suggest_routes_returns_empty_when_no_similar_routes() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store
             .set_route(make_route("GET", "/completely/different/path"))
             .unwrap();
@@ -432,7 +459,7 @@ mod tests {
 
     #[test]
     fn suggest_routes_caps_results_at_limit() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         store.set_route(make_route("GET", "/api/users")).unwrap();
         store.set_route(make_route("GET", "/api/user")).unwrap();
         store
@@ -452,7 +479,7 @@ mod tests {
 
     #[test]
     fn suggest_routes_returns_empty_when_store_is_empty() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         let suggestions = store.suggest_routes("GET", "/api/users");
         assert!(suggestions.is_empty());
     }
@@ -462,13 +489,14 @@ mod tests {
             match_key: MatchKey::new(verb, pattern),
             set_state: None,
             simulation: None,
+            max_calls: None,
             response,
         }
     }
 
     #[test]
     fn single_content_is_accepted() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         let result = store.set_route(make_route_with_response("GET", "/a", ResponseDefinition {
             content: Some("hello".to_string()),
             ..Default::default()
@@ -478,7 +506,7 @@ mod tests {
 
     #[test]
     fn single_content_file_is_accepted() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         let result = store.set_route(make_route_with_response("GET", "/b", ResponseDefinition {
             content_file: Some("/some/file.txt".to_string()),
             ..Default::default()
@@ -488,7 +516,7 @@ mod tests {
 
     #[test]
     fn single_binary_file_is_accepted() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         let result = store.set_route(make_route_with_response("GET", "/c", ResponseDefinition {
             binary_file: Some("/some/file.bin".to_string()),
             ..Default::default()
@@ -498,7 +526,7 @@ mod tests {
 
     #[test]
     fn single_loopback_is_accepted() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         let result = store.set_route(make_route_with_response("GET", "/d", ResponseDefinition {
             loopback: true,
             ..Default::default()
@@ -508,7 +536,7 @@ mod tests {
 
     #[test]
     fn content_and_content_file_together_is_rejected() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         let err = store.set_route(make_route_with_response("GET", "/e", ResponseDefinition {
             content: Some("hello".to_string()),
             content_file: Some("/some/file.txt".to_string()),
@@ -519,7 +547,7 @@ mod tests {
 
     #[test]
     fn content_and_binary_file_together_is_rejected() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         let err = store.set_route(make_route_with_response("GET", "/f", ResponseDefinition {
             content: Some("hello".to_string()),
             binary_file: Some("/some/file.bin".to_string()),
@@ -530,7 +558,7 @@ mod tests {
 
     #[test]
     fn content_file_and_binary_file_together_is_rejected() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         let err = store.set_route(make_route_with_response("GET", "/g", ResponseDefinition {
             content_file: Some("/some/file.txt".to_string()),
             binary_file: Some("/some/file.bin".to_string()),
@@ -541,7 +569,7 @@ mod tests {
 
     #[test]
     fn loopback_and_content_together_is_rejected() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         let err = store.set_route(make_route_with_response("GET", "/h", ResponseDefinition {
             loopback: true,
             content: Some("hello".to_string()),
@@ -552,12 +580,36 @@ mod tests {
 
     #[test]
     fn loopback_and_content_file_together_is_rejected() {
-        let store = RouteStore::new();
+        let store = RouteStore::default();
         let err = store.set_route(make_route_with_response("GET", "/i", ResponseDefinition {
             loopback: true,
             content_file: Some("/some/file.txt".to_string()),
             ..Default::default()
         })).unwrap_err();
         assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn max_routes_limit_is_enforced() {
+        let store = RouteStore::new(1, 10 * 1024 * 1024);
+        store.set_route(make_route("GET", "/first")).unwrap();
+        let err = store.set_route(make_route("GET", "/second")).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn max_content_size_limit_is_enforced() {
+        let store = RouteStore::new(1000, 5);
+        let err = store.set_route(make_route_with_response("GET", "/too-big", ResponseDefinition {
+            content: Some("123456".to_string()),
+            ..Default::default()
+        })).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+
+        let ok = store.set_route(make_route_with_response("GET", "/just-right", ResponseDefinition {
+            content: Some("12345".to_string()),
+            ..Default::default()
+        }));
+        assert!(ok.is_ok());
     }
 }

--- a/bamboozle/src/routing/store.rs
+++ b/bamboozle/src/routing/store.rs
@@ -111,6 +111,12 @@ impl RouteStore {
             }
         }
 
+        if def.max_calls == Some(0) {
+            return Err(AppError::BadRequest(
+                "'maxCalls' must be greater than 0".to_string(),
+            ));
+        }
+
         let verb = def.match_key.verb.trim().to_ascii_uppercase();
         // `pattern` preserves case inside {braces} so param names match Liquid template
         // access (e.g. `{{routeValues.thingName}}`), but lowercases literal segments.
@@ -158,7 +164,8 @@ impl RouteStore {
                 normalized_pattern: pattern,
             },
         );
-        self.route_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.route_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         info!(route = %key_str, "Route set");
         Ok(def)
@@ -182,7 +189,8 @@ impl RouteStore {
             return Err(RouteError::NotFound(key_str));
         }
 
-        self.route_count.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        self.route_count
+            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
         info!(route = %key_str, "Route deleted");
         Ok(())
     }
@@ -242,14 +250,18 @@ impl RouteStore {
                 let stored_verb = outer.key().clone();
                 let normalized = normalized.clone();
                 let verb_upper = verb_upper.clone();
-                outer.value().iter().map(move |inner| {
-                    let pattern = &inner.value().normalized_pattern;
-                    let mut score = jaro_winkler(normalized.as_str(), pattern.as_str());
-                    if stored_verb == verb_upper {
-                        score += 0.05;
-                    }
-                    (score, format!("{}|{}", stored_verb, pattern))
-                }).collect::<Vec<_>>()
+                outer
+                    .value()
+                    .iter()
+                    .map(move |inner| {
+                        let pattern = &inner.value().normalized_pattern;
+                        let mut score = jaro_winkler(normalized.as_str(), pattern.as_str());
+                        if stored_verb == verb_upper {
+                            score += 0.05;
+                        }
+                        (score, format!("{}|{}", stored_verb, pattern))
+                    })
+                    .collect::<Vec<_>>()
             })
             .filter(|(score, _)| *score >= SUGGESTION_THRESHOLD)
             .collect();
@@ -274,7 +286,8 @@ impl RouteStore {
 
     pub fn reset(&self) {
         self.routes.clear();
-        self.route_count.store(0, std::sync::atomic::Ordering::Relaxed);
+        self.route_count
+            .store(0, std::sync::atomic::Ordering::Relaxed);
         info!("Route store cleared");
     }
 }
@@ -484,7 +497,11 @@ mod tests {
         assert!(suggestions.is_empty());
     }
 
-    fn make_route_with_response(verb: &str, pattern: &str, response: ResponseDefinition) -> RouteDefinition {
+    fn make_route_with_response(
+        verb: &str,
+        pattern: &str,
+        response: ResponseDefinition,
+    ) -> RouteDefinition {
         RouteDefinition {
             match_key: MatchKey::new(verb, pattern),
             set_state: None,
@@ -497,95 +514,141 @@ mod tests {
     #[test]
     fn single_content_is_accepted() {
         let store = RouteStore::default();
-        let result = store.set_route(make_route_with_response("GET", "/a", ResponseDefinition {
-            content: Some("hello".to_string()),
-            ..Default::default()
-        }));
+        let result = store.set_route(make_route_with_response(
+            "GET",
+            "/a",
+            ResponseDefinition {
+                content: Some("hello".to_string()),
+                ..Default::default()
+            },
+        ));
         assert!(result.is_ok());
     }
 
     #[test]
     fn single_content_file_is_accepted() {
         let store = RouteStore::default();
-        let result = store.set_route(make_route_with_response("GET", "/b", ResponseDefinition {
-            content_file: Some("/some/file.txt".to_string()),
-            ..Default::default()
-        }));
+        let result = store.set_route(make_route_with_response(
+            "GET",
+            "/b",
+            ResponseDefinition {
+                content_file: Some("/some/file.txt".to_string()),
+                ..Default::default()
+            },
+        ));
         assert!(result.is_ok());
     }
 
     #[test]
     fn single_binary_file_is_accepted() {
         let store = RouteStore::default();
-        let result = store.set_route(make_route_with_response("GET", "/c", ResponseDefinition {
-            binary_file: Some("/some/file.bin".to_string()),
-            ..Default::default()
-        }));
+        let result = store.set_route(make_route_with_response(
+            "GET",
+            "/c",
+            ResponseDefinition {
+                binary_file: Some("/some/file.bin".to_string()),
+                ..Default::default()
+            },
+        ));
         assert!(result.is_ok());
     }
 
     #[test]
     fn single_loopback_is_accepted() {
         let store = RouteStore::default();
-        let result = store.set_route(make_route_with_response("GET", "/d", ResponseDefinition {
-            loopback: true,
-            ..Default::default()
-        }));
+        let result = store.set_route(make_route_with_response(
+            "GET",
+            "/d",
+            ResponseDefinition {
+                loopback: true,
+                ..Default::default()
+            },
+        ));
         assert!(result.is_ok());
     }
 
     #[test]
     fn content_and_content_file_together_is_rejected() {
         let store = RouteStore::default();
-        let err = store.set_route(make_route_with_response("GET", "/e", ResponseDefinition {
-            content: Some("hello".to_string()),
-            content_file: Some("/some/file.txt".to_string()),
-            ..Default::default()
-        })).unwrap_err();
+        let err = store
+            .set_route(make_route_with_response(
+                "GET",
+                "/e",
+                ResponseDefinition {
+                    content: Some("hello".to_string()),
+                    content_file: Some("/some/file.txt".to_string()),
+                    ..Default::default()
+                },
+            ))
+            .unwrap_err();
         assert!(matches!(err, AppError::BadRequest(_)));
     }
 
     #[test]
     fn content_and_binary_file_together_is_rejected() {
         let store = RouteStore::default();
-        let err = store.set_route(make_route_with_response("GET", "/f", ResponseDefinition {
-            content: Some("hello".to_string()),
-            binary_file: Some("/some/file.bin".to_string()),
-            ..Default::default()
-        })).unwrap_err();
+        let err = store
+            .set_route(make_route_with_response(
+                "GET",
+                "/f",
+                ResponseDefinition {
+                    content: Some("hello".to_string()),
+                    binary_file: Some("/some/file.bin".to_string()),
+                    ..Default::default()
+                },
+            ))
+            .unwrap_err();
         assert!(matches!(err, AppError::BadRequest(_)));
     }
 
     #[test]
     fn content_file_and_binary_file_together_is_rejected() {
         let store = RouteStore::default();
-        let err = store.set_route(make_route_with_response("GET", "/g", ResponseDefinition {
-            content_file: Some("/some/file.txt".to_string()),
-            binary_file: Some("/some/file.bin".to_string()),
-            ..Default::default()
-        })).unwrap_err();
+        let err = store
+            .set_route(make_route_with_response(
+                "GET",
+                "/g",
+                ResponseDefinition {
+                    content_file: Some("/some/file.txt".to_string()),
+                    binary_file: Some("/some/file.bin".to_string()),
+                    ..Default::default()
+                },
+            ))
+            .unwrap_err();
         assert!(matches!(err, AppError::BadRequest(_)));
     }
 
     #[test]
     fn loopback_and_content_together_is_rejected() {
         let store = RouteStore::default();
-        let err = store.set_route(make_route_with_response("GET", "/h", ResponseDefinition {
-            loopback: true,
-            content: Some("hello".to_string()),
-            ..Default::default()
-        })).unwrap_err();
+        let err = store
+            .set_route(make_route_with_response(
+                "GET",
+                "/h",
+                ResponseDefinition {
+                    loopback: true,
+                    content: Some("hello".to_string()),
+                    ..Default::default()
+                },
+            ))
+            .unwrap_err();
         assert!(matches!(err, AppError::BadRequest(_)));
     }
 
     #[test]
     fn loopback_and_content_file_together_is_rejected() {
         let store = RouteStore::default();
-        let err = store.set_route(make_route_with_response("GET", "/i", ResponseDefinition {
-            loopback: true,
-            content_file: Some("/some/file.txt".to_string()),
-            ..Default::default()
-        })).unwrap_err();
+        let err = store
+            .set_route(make_route_with_response(
+                "GET",
+                "/i",
+                ResponseDefinition {
+                    loopback: true,
+                    content_file: Some("/some/file.txt".to_string()),
+                    ..Default::default()
+                },
+            ))
+            .unwrap_err();
         assert!(matches!(err, AppError::BadRequest(_)));
     }
 
@@ -600,16 +663,26 @@ mod tests {
     #[test]
     fn max_content_size_limit_is_enforced() {
         let store = RouteStore::new(1000, 5);
-        let err = store.set_route(make_route_with_response("GET", "/too-big", ResponseDefinition {
-            content: Some("123456".to_string()),
-            ..Default::default()
-        })).unwrap_err();
+        let err = store
+            .set_route(make_route_with_response(
+                "GET",
+                "/too-big",
+                ResponseDefinition {
+                    content: Some("123456".to_string()),
+                    ..Default::default()
+                },
+            ))
+            .unwrap_err();
         assert!(matches!(err, AppError::BadRequest(_)));
 
-        let ok = store.set_route(make_route_with_response("GET", "/just-right", ResponseDefinition {
-            content: Some("12345".to_string()),
-            ..Default::default()
-        }));
+        let ok = store.set_route(make_route_with_response(
+            "GET",
+            "/just-right",
+            ResponseDefinition {
+                content: Some("12345".to_string()),
+                ..Default::default()
+            },
+        ));
         assert!(ok.is_ok());
     }
 }

--- a/bamboozle/src/tracking/tracker.rs
+++ b/bamboozle/src/tracking/tracker.rs
@@ -104,6 +104,7 @@ mod tests {
                 match_key: MatchKey::new(verb, pattern),
                 set_state: None,
                 simulation: None,
+                max_calls: None,
                 response: ResponseDefinition::default(),
             },
             previous_context: None,

--- a/bamboozle/src/tracking/tracker.rs
+++ b/bamboozle/src/tracking/tracker.rs
@@ -56,6 +56,15 @@ impl CallTracker {
         calls
     }
 
+    pub fn get_call_count_for_route(&self, key: &MatchKey) -> usize {
+        let count = self
+            .matched
+            .iter()
+            .filter(|entry| entry.value().route_model.match_key == *key)
+            .count();
+        count
+    }
+
     pub fn delete_calls_for_route(&self, key: &MatchKey) {
         self.matched
             .retain(|_, ctx| ctx.route_model.match_key != *key);

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -6,7 +6,7 @@ All variables Bamboozle reads at startup.
 |---|---|---|
 | `ROUTE_CONFIG_FOLDERS` | `[]` | JSON array of directory paths to scan for `.json`, `.yaml`, `.yml` route files |
 | `ROUTE_CONFIG_THROW_ON_ERROR` | `false` | When `true`, fail startup if any route file can't be parsed |
-| `MAX_ROUTES` | `1000` | Maximum number of dynamically configurable routes |
+| `MAX_ROUTES` | `1000` | Maximum number of routes that can be loaded or configured |
 | `MAX_CONTENT_SIZE_BYTES` | `10485760` | Maximum allowed inline content size (in bytes) for a single route definition (default: 10 MB) |
 | `TLS_CERT_FILE` | unset | Path to a PEM-encoded TLS certificate file — setting this (with `TLS_KEY_FILE`) enables HTTPS on the mock port |
 | `TLS_KEY_FILE` | unset | Path to a PEM-encoded TLS private key file — must be set together with `TLS_CERT_FILE` |

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -6,6 +6,8 @@ All variables Bamboozle reads at startup.
 |---|---|---|
 | `ROUTE_CONFIG_FOLDERS` | `[]` | JSON array of directory paths to scan for `.json`, `.yaml`, `.yml` route files |
 | `ROUTE_CONFIG_THROW_ON_ERROR` | `false` | When `true`, fail startup if any route file can't be parsed |
+| `MAX_ROUTES` | `1000` | Maximum number of dynamically configurable routes |
+| `MAX_CONTENT_SIZE_BYTES` | `10485760` | Maximum allowed inline content size (in bytes) for a single route definition (default: 10 MB) |
 | `TLS_CERT_FILE` | unset | Path to a PEM-encoded TLS certificate file — setting this (with `TLS_KEY_FILE`) enables HTTPS on the mock port |
 | `TLS_KEY_FILE` | unset | Path to a PEM-encoded TLS private key file — must be set together with `TLS_CERT_FILE` |
 | `RUST_LOG` | `info` | Log level filter — standard `env_logger` syntax (`trace`, `debug`, `info`, `warn`, `error`) |

--- a/docs/reference/route-definition.md
+++ b/docs/reference/route-definition.md
@@ -9,6 +9,7 @@ The JSON/YAML schema for a route. Used in `POST /control/routes`, `PUT /control/
 | `match` | `MatchKey` | yes | Identifies the route |
 | `response` | `ResponseDefinition` | yes | What to return |
 | `setState` | string | no | Liquid template — evaluated after each match, result stored as `state` |
+| `maxCalls` | number | no | Delete the route after it has been called this many times |
 | `simulation` | `SimulationConfig` | no | Latency or fault injection |
 
 ## `MatchKey`

--- a/playwright/tests/response.spec.ts
+++ b/playwright/tests/response.spec.ts
@@ -95,6 +95,51 @@ test.describe('request body loopback should match original', () => {
     }
 });
 
+test.describe('max calls returns 404', () => {
+    let deleteState: MatchKey[] = [];
+    test.afterEach(async () => {
+        for (let key of deleteState) {
+            try {
+                await bamboozleClient.clearCalls(key.verb, key.pattern);
+                await bamboozleClient.deleteRoute(key.verb, key.pattern);
+            }
+            catch { }
+        }
+        deleteState = [];
+    });
+    const verbs: string[] = ['PUT', 'POST', 'PATCH'];
+    for (let verb of verbs) {
+        test(verb, async ({ request }) => {
+            const key: MatchKey = { verb: verb, pattern: 'playwright/max/calls/returns/404' };
+            deleteState.push(key);
+            await bamboozleClient.addRoute({
+                match: key,
+                response: {
+                    status: "200",
+                    loopback: true
+                },
+                maxCalls: 1
+            });
+            const initReq = await reqFactory(verb, `http://localhost:18080/${key.pattern}`, request, {
+                hello: "world",
+                number: 24
+            });
+            const init = await initReq.json();
+            expect(init).toBeDefined();
+            expect(init.hello).toEqual("world");
+            expect(init.number).toEqual(24);
+            expect(await bamboozleClient.assert(key.verb, key.pattern, { calledExactly: 1 })).toBeTruthy();
+            expect(initReq.headers()["content-type"]).toBe("application/json");
+
+            const secReq = await reqFactory(verb, `http://localhost:18080/${key.pattern}`, request, {
+                hello: "world",
+                number: 24
+            });
+            expect(secReq.status()).toBe(404);
+        });
+    }
+});
+
 test.describe('route matching', () => {
     let deleteState: MatchKey[] = [];
     test.afterEach(async () => {

--- a/sdks/dotnet/Bamboozle/Bamboozle.Core/Models.cs
+++ b/sdks/dotnet/Bamboozle/Bamboozle.Core/Models.cs
@@ -24,6 +24,7 @@ public record RouteDefinition
     public required ResponseDefinition Response { get; set; }
     public string? SetState { get; set; }
     public SimulationConfig? Simulation { get; set; }
+    public int? MaxCalls { get; set; }
 }
 
 public record ResponseDefinition
@@ -69,7 +70,7 @@ public sealed record GaussianDelayConfig : DelayConfig
 
 public class CamelCaseEnumConverter : JsonStringEnumConverter
 {
-    public CamelCaseEnumConverter() : base(JsonNamingPolicy.CamelCase) {}
+    public CamelCaseEnumConverter() : base(JsonNamingPolicy.CamelCase) { }
 }
 
 public record FaultConfig

--- a/sdks/npm/src/types.ts
+++ b/sdks/npm/src/types.ts
@@ -35,7 +35,7 @@ export interface RouteDefinition {
   response: ResponseDefinition;
   setState?: string;
   simulation?: SimulationConfig;
-  maxCalls?: number
+  maxCalls?: number;
 }
 
 export interface ContextModel {

--- a/sdks/npm/src/types.ts
+++ b/sdks/npm/src/types.ts
@@ -35,6 +35,7 @@ export interface RouteDefinition {
   response: ResponseDefinition;
   setState?: string;
   simulation?: SimulationConfig;
+  maxCalls?: number
 }
 
 export interface ContextModel {


### PR DESCRIPTION
closes #17 
This PR adds the `maxCalls` property to the route definition which automatically deletes the route when the condition is reached. We have also added a configurable cap on the max number of routes, and a configurable cap on the max response content size.